### PR TITLE
Interactive prompts

### DIFF
--- a/client.go
+++ b/client.go
@@ -282,6 +282,10 @@ func (c *Client) Create(language, name, root string) (err error) {
 	// is still manual.
 	c.dnsProvider.Provide(f.name, address)
 
+	// TODO: Create a status structure and return it for clients to use
+	// for output, such as from the CLI.
+	fmt.Printf("https://%v/\n", f.name)
+
 	return
 }
 
@@ -444,5 +448,5 @@ func (n *noopLister) List() ([]string, error) {
 type noopDNSProvider struct{ output io.Writer }
 
 func (n *noopDNSProvider) Provide(name, address string) {
-	fmt.Fprintf(n.output, "Note: manual DNS provisioning may be required name=%v address%v\n", name, address)
+	// Note: at this time manual DNS provisioning required for name -> knative serving netowrk load-balancer
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -109,5 +109,4 @@ func create(cmd *cobra.Command, args []string) (err error) {
 	// Name can be empty string (path-dervation will be attempted)
 	// Path can be empty, defaulting to current working directory.
 	return client.Create(language, name, path)
-
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"regexp"
 
 	"github.com/ory/viper"
@@ -111,15 +110,11 @@ func create(cmd *cobra.Command, args []string) (err error) {
 	// If we are running as an interactive terminal, allow the user
 	// to mutate default config prior to execution.
 	if isInteractive() {
-		fmt.Printf("Initial Config: \n%#v\n", config)
 		config, err = gatherFromUser(config)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Final Config: \n%#v", config)
 	}
-
-	return
 
 	// Initializer creates a deployable noop function implementation in the
 	// configured path.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -9,9 +9,7 @@ import (
 
 func init() {
 	root.AddCommand(deleteCmd)
-
 	deleteCmd.Flags().StringP("name", "n", "", "optionally specify an explicit name to remove, overriding path-derivation. $FAAS_NAME")
-	viper.BindPFlag("name", deleteCmd.Flags().Lookup("name"))
 }
 
 var deleteCmd = &cobra.Command{
@@ -20,6 +18,9 @@ var deleteCmd = &cobra.Command{
 	Long:       `Removes the deployed Service Function for the current directory, but does not delete anything locally.  If no code updates have been made beyond the defaults, this would bring the current codebase back to a state equivalent to having run "create --local".`,
 	SuggestFor: []string{"remove", "rm"},
 	RunE:       delete,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag("name", cmd.Flags().Lookup("name"))
+	},
 }
 
 func delete(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -18,10 +18,8 @@ func init() {
 	root.AddCommand(describeCmd)
 
 	describeCmd.Flags().StringP("output", "o", "yaml", "optionally specify output format (yaml,xml,json).")
-	viper.BindPFlag("output", describeCmd.Flags().Lookup("output"))
 
 	describeCmd.Flags().StringP("name", "n", "", "optionally specify an explicit name for the serive, overriding path-derivation. $FAAS_NAME")
-	viper.BindPFlag("name", describeCmd.Flags().Lookup("name"))
 }
 
 var describeCmd = &cobra.Command{
@@ -30,6 +28,10 @@ var describeCmd = &cobra.Command{
 	Long:       `Describe Service Function`,
 	SuggestFor: []string{"desc"},
 	RunE:       describe,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		viper.BindPFlag("output", cmd.Flags().Lookup("output"))
+		viper.BindPFlag("name", cmd.Flags().Lookup("name"))
+	},
 }
 
 func describe(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,3 +62,11 @@ func Execute() {
 		os.Exit(1)
 	}
 }
+
+// isInteractive returns whether or not the currently attached process terminal
+// is interactive.  Used for determining whether or not to interactively prompt
+// the user to confirm default choices, etc.
+func isInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	return err == nil && ((fi.Mode() & os.ModeCharDevice) != 0)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -8,7 +8,7 @@ import (
 
 // Version
 // Printed on subcommand `version` or flag `--version`
-const Version = "v0.0.16"
+const Version = "v0.0.17"
 
 func init() {
 	root.AddCommand(versionCmd)

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package faas
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -39,7 +38,6 @@ func newConfig(f *Function) Config {
 
 // writeConfig out to disk.
 func writeConfig(f *Function) (err error) {
-	fmt.Printf("Writing config for function: %#v\n", f)
 	var (
 		cfg     = newConfig(f)
 		cfgFile = filepath.Join(f.root, ConfigFileName)

--- a/function.go
+++ b/function.go
@@ -37,6 +37,12 @@ func NewFunction(root string) (f *Function, err error) {
 	return
 }
 
+// DerivedName returns the name that will be used if path derivation is choosen, limited in its upward recursion.
+// This is exposed for preemptive calculation for interactive confirmation, such as via a CLI.
+func (f *Function) DerivedName(searchLimit int) string {
+	return pathToDomain(f.root, searchLimit)
+}
+
 func (f *Function) Initialize(language, name string, domainSearchLimit int, initializer Initializer) (err error) {
 	// Assert language is provided
 	if language == "" {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	contrib.go.opencensus.io/exporter/ocagent v0.6.0 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.1 // indirect
-	github.com/docker/docker-credential-helpers v0.6.3
 	github.com/google/go-containerregistry v0.0.0-20200423114255-8f808463544c // indirect
 	github.com/openzipkin/zipkin-go v0.2.2 // indirect
 	github.com/ory/viper v1.7.4

--- a/kubectl/deployer.go
+++ b/kubectl/deployer.go
@@ -15,6 +15,9 @@ import (
 	"github.com/boson-project/faas/k8s"
 )
 
+// TODO: Replace this implementation with an implementation which
+// directly uses the client, using this as a reference.
+
 const service = `
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -123,6 +126,6 @@ func (d *Deployer) Deploy(name, image string) (address string, err error) {
 		return
 	}
 
-	// TODO: explicitly pull address:
-	return "https://faas.example.com/", nil
+	// TODO: explicitly pull address from API.  The Knative Serving Networking LB.
+	return "[cluster-address]", nil
 }

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -1,0 +1,199 @@
+package prompt
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Default delimiter between prompt and user input.  Includes a space such that
+// overrides have full control of spacing.
+const DefaultDelimiter = ": "
+
+// DefaultRetryLimit imposed for a few reasons, not least of which infinite
+// loops in tests.
+const DefaultRetryLimit = 10
+
+type prompt struct {
+	in         io.Reader
+	out        io.Writer
+	label      string
+	delim      string
+	required   bool
+	retryLimit int
+}
+
+type stringPrompt struct {
+	prompt
+	dflt string
+}
+
+type boolPrompt struct {
+	prompt
+	dflt bool
+}
+
+type Option func(*prompt)
+
+func WithInput(in io.Reader) Option {
+	return func(p *prompt) {
+		p.in = in
+	}
+}
+
+func WithOutput(out io.Writer) Option {
+	return func(p *prompt) {
+		p.out = out
+	}
+}
+
+func WithDelimiter(d string) Option {
+	return func(p *prompt) {
+		p.delim = d
+	}
+}
+
+func WithRequired(r bool) Option {
+	return func(p *prompt) {
+		p.required = r
+	}
+}
+
+func WithRetryLimit(l int) Option {
+	return func(p *prompt) {
+		p.retryLimit = l
+	}
+}
+
+func ForString(label string, dflt string, options ...Option) string {
+	p := &stringPrompt{
+		prompt: prompt{
+			in:         os.Stdin,
+			out:        os.Stdout,
+			label:      label,
+			delim:      DefaultDelimiter,
+			retryLimit: DefaultRetryLimit,
+		},
+		dflt: dflt,
+	}
+	for _, o := range options {
+		o(&p.prompt)
+	}
+
+	writeStringLabel(p)         // Write the label
+	input, err := readString(p) // gather the input
+	var attempt int
+	for err != nil && attempt < p.retryLimit { // while there are errors
+		attempt++
+		writeError(err, &p.prompt) // write the error on its own line
+		writeStringLabel(p)        // re-write the label
+		input, err = readString(p) // re-read the input
+	}
+	return input
+}
+
+func writeStringLabel(p *stringPrompt) {
+	p.out.Write([]byte(p.label))
+	if p.dflt != "" {
+		if p.label != "" {
+			p.out.Write([]byte(" "))
+		}
+		fmt.Fprintf(p.out, "(%v)", p.dflt)
+	}
+	p.out.Write([]byte(p.delim))
+}
+
+func readString(p *stringPrompt) (s string, err error) {
+	if s, err = bufio.NewReader(p.in).ReadString('\n'); err != nil {
+		return
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		s = p.dflt
+	}
+	if s == "" && p.required {
+		err = errors.New("please enter a value")
+	}
+	return
+}
+
+func ForBool(label string, dflt bool, options ...Option) bool {
+	p := &boolPrompt{
+		prompt: prompt{
+			in:         os.Stdin,
+			out:        os.Stdout,
+			label:      label,
+			delim:      DefaultDelimiter,
+			retryLimit: DefaultRetryLimit,
+		},
+		dflt: dflt,
+	}
+	for _, o := range options {
+		o(&p.prompt)
+	}
+
+	writeBoolLabel(p)         // write the prompt label
+	input, err := readBool(p) // gather the input
+	var attempt int
+	for err != nil && attempt < p.retryLimit {
+		attempt++
+		writeError(err, &p.prompt) // write the error on its own line
+		writeBoolLabel(p)          // re-write the label
+		input, err = readBool(p)   // re-read the input
+	}
+
+	return input
+}
+
+func writeBoolLabel(p *boolPrompt) {
+	p.out.Write([]byte(p.label))
+	if p.label != "" {
+		p.out.Write([]byte(" "))
+	}
+	if p.dflt == true {
+		fmt.Fprint(p.out, "(Y/n)")
+	} else {
+		fmt.Fprint(p.out, "(y/N)")
+	}
+	p.out.Write([]byte(p.delim))
+}
+
+func readBool(p *boolPrompt) (bool, error) {
+	reader := bufio.NewReader(p.in)
+	var s string
+	s, err := reader.ReadString('\n')
+	if err != nil {
+		return p.dflt, err
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return p.dflt, nil
+	}
+	if isTruthy(s) { // variants of 'true'
+		return true, nil
+	} else if isFalsy(s) {
+		return false, nil
+	}
+	return strconv.ParseBool(s)
+}
+
+var truthy = regexp.MustCompile("(?i)y(?:es)?|1")
+var falsy = regexp.MustCompile("(?i)n(?:o)?|0")
+
+func isTruthy(confirm string) bool {
+	return truthy.MatchString(confirm)
+}
+
+func isFalsy(confirm string) bool {
+	return falsy.MatchString(confirm)
+}
+
+func writeError(err error, p *prompt) {
+	p.out.Write([]byte("\n"))
+	fmt.Fprintln(p.out, err)
+}

--- a/prompt/prompt_test.go
+++ b/prompt/prompt_test.go
@@ -1,0 +1,245 @@
+package prompt_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/boson-project/faas/prompt"
+)
+
+// TestForStringLabel ensures that a string prompt with a given label is printed to stdout.
+func TestForStringLabel(t *testing.T) {
+
+	var out bytes.Buffer
+	var in bytes.Buffer
+	in.Write([]byte("\n"))
+
+	// Empty label
+	_ = prompt.ForString("", "",
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if string(out.Bytes()) != ": " {
+		t.Fatalf("expected output to be ': ', got '%v'\n", string(out.Bytes()))
+	}
+
+	out.Reset()
+	in.Reset()
+
+	in.Write([]byte("\n"))
+
+	// Populated lable
+	_ = prompt.ForString("Name", "",
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if string(out.Bytes()) != "Name: " {
+		t.Fatalf("expected 'Name', got '%v'\n", string(out.Bytes()))
+	}
+}
+
+// TestForStringLabelDefault ensures that a default, only if provided, is appended
+// to the prompt label.
+func TestForStringLabelDefault(t *testing.T) {
+	var out bytes.Buffer
+	var in bytes.Buffer
+	in.Write([]byte("\n")) // [ENTER]
+
+	// No lablel but a default
+	_ = prompt.ForString("", "Alice",
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if string(out.Bytes()) != "(Alice): " {
+		t.Fatalf("expected '(Alice): ', got '%v'\n", string(out.Bytes()))
+	}
+
+	out.Reset()
+	in.Reset()
+	in.Write([]byte("\n")) // [ENTER]
+
+	// Label with default
+	_ = prompt.ForString("Name", "Alice",
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if string(out.Bytes()) != "Name (Alice): " {
+		t.Fatalf("expected 'Name (Alice): ', got '%v'\n", string(out.Bytes()))
+	}
+}
+
+// TestForStringLabelDelimiter ensures that a default delimiter override is respected.
+func TestWithDelimiter(t *testing.T) {
+	var out bytes.Buffer
+	var in bytes.Buffer
+	in.Write([]byte("\n")) // [ENTER]
+
+	_ = prompt.ForString("", "",
+		prompt.WithInput(&in),
+		prompt.WithOutput(&out),
+		prompt.WithDelimiter("Δ"))
+	if string(out.Bytes()) != "Δ" {
+		t.Fatalf("expected output to be 'Δ', got '%v'\n", string(out.Bytes()))
+	}
+}
+
+// TestForStringDefault ensures that the default is returned when enter is
+// pressed on a string input.
+func TestForStringDefault(t *testing.T) {
+	var out bytes.Buffer
+	var in bytes.Buffer
+	in.Write([]byte("\n")) // [ENTER]
+
+	// Empty default should return an empty value.
+	s := prompt.ForString("", "",
+		prompt.WithInput(&in),
+		prompt.WithOutput(&out))
+
+	if s != "" {
+		t.Fatalf("expected '', got '%v'\n", s)
+	}
+
+	in.Reset()
+	out.Reset()
+	in.Write([]byte("\n")) // [ENTER]
+
+	// Extant default should be returned
+	s = prompt.ForString("", "default",
+		prompt.WithInput(&in),
+		prompt.WithOutput(&out))
+
+	if s != "default" {
+		t.Fatalf("expected 'default', got '%v'\n", s)
+	}
+}
+
+// TestForStringRequired ensures that an error is generated if a value is not
+// provided for a required prompt with no default.
+func TestForStringRequired(t *testing.T) {
+	var out bytes.Buffer
+	var in bytes.Buffer
+	in.Write([]byte("\n")) // [ENTER]
+
+	_ = prompt.ForString("", "",
+		prompt.WithInput(&in),
+		prompt.WithOutput(&out),
+		prompt.WithRequired(true),
+		prompt.WithRetryLimit(1)) // makes the output buffer easier to confirm
+
+	output := string(out.Bytes())
+	expected := ": \nplease enter a value\n: "
+	if output != expected {
+		t.Fatalf("Unexpected prompt received for a required value.", expected, output)
+	}
+}
+
+// TestForString ensures that string input is accepted.
+func TestForString(t *testing.T) {
+	var in bytes.Buffer
+	var out bytes.Buffer
+	in.Write([]byte("hunter2\n"))
+
+	s := prompt.ForString("", "",
+		prompt.WithInput(&in),
+		prompt.WithOutput(&out))
+	if s != "hunter2" {
+		t.Fatalf("Expected 'hunter2' got '%v'", s)
+	}
+}
+
+// TestForBoolLabel ensures that a prompt for a given boolean prompt prints
+// the expected y/n prompt.
+func TestForBoolLabel(t *testing.T) {
+	var out bytes.Buffer
+	var in bytes.Buffer
+	in.Write([]byte("\n"))
+
+	// Empty label, default false
+	_ = prompt.ForBool("", false,
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if string(out.Bytes()) != "(y/N): " {
+		t.Fatalf("expected output to be '(y/N): ', got '%v'\n", string(out.Bytes()))
+	}
+
+	out.Reset()
+	in.Reset()
+
+	in.Write([]byte("\n"))
+
+	// Empty label, default true
+	_ = prompt.ForBool("", true,
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if string(out.Bytes()) != "(Y/n): " {
+		t.Fatalf("expected output to be '(Y/n): ', got '%v'\n", string(out.Bytes()))
+	}
+
+	out.Reset()
+	in.Reset()
+
+	in.Write([]byte("\n"))
+
+	// Populated lablel default false
+	_ = prompt.ForBool("Local", false,
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if string(out.Bytes()) != "Local (y/N): " {
+		t.Fatalf("expected 'Local (y/N): ', got '%v'\n", string(out.Bytes()))
+	}
+}
+
+// TestForBoolDefault ensures that the default is returned when no user input is given.
+func TestForBoolDefault(t *testing.T) {
+	var out bytes.Buffer
+	var in bytes.Buffer
+	in.Write([]byte("\n"))
+
+	b := prompt.ForBool("", false,
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if b != false {
+		t.Fatal("expected default of false to be returned when user accepts.")
+	}
+
+	out.Reset()
+	in.Reset()
+
+	in.Write([]byte("\n"))
+
+	b = prompt.ForBool("", true,
+		prompt.WithInput(&in), prompt.WithOutput(&out))
+	if b != true {
+		t.Fatal("expected default of true to be returned when user accepts.")
+	}
+}
+
+// TestForBool ensures that a truthy value, when entered, is returned as a bool.
+func TestForBool(t *testing.T) {
+	var out bytes.Buffer
+	var in bytes.Buffer
+
+	cases := []struct {
+		in  string
+		out bool
+	}{
+		{"true", true},
+		{"1", true},
+		{"y", true},
+		{"Y", true},
+		{"yes", true},
+		{"Yes", true},
+		{"YES", true},
+		{"false", false},
+		{"0", false},
+		{"n", false},
+		{"N", false},
+		{"no", false},
+		{"No", false},
+		{"NO", false},
+	}
+
+	for _, c := range cases {
+		in.Reset()
+		out.Reset()
+		fmt.Fprintf(&in, "%v\n", c.in)
+
+		// Note the default value is always the oposite of the input
+		// to ensure it is flipped.
+		b := prompt.ForBool("", !c.out,
+			prompt.WithInput(&in), prompt.WithOutput(&out))
+		if b != c.out {
+			t.Fatalf("expected '%v' to be an acceptable %v.", c.in, c.out)
+		}
+
+	}
+}


### PR DESCRIPTION
Adds interactive prompts to the create command, with default values either calculated or provided via flags and environment variables.  This interactivity is disabled if the attached terminal is non-interactive.

This also fixes a problem with flags where they would silently fail to attach due to being initialized on multiple subcommands.  This was fixed by moving the registration into PreRun from the static initializer.  Fixes #8 