### PR TITLE
build: utilize docker latest tag for releases only

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -23,7 +23,9 @@ jobs:
         env:
           USER: ${{ secrets.QUAY_USERNAME }}
           PASS: ${{ secrets.QUAY_PASSWORD }}
-        run: docker login -u "$USER" -p "$PASS" quay.io && make push
+        run: |
+          docker login -u "$USER" -p "$PASS" quay.io 
+          make push && make latest
       - name: Compress Release Binary
         run: gzip ./faas
       - name: Create Release

--- a/Makefile
+++ b/Makefile
@@ -17,20 +17,26 @@ test:
 	go test -cover -coverprofile=coverage.out ./...
 
 image: Dockerfile
-	docker build -t $(REPO):$(VERS) \
+	docker build -t $(REPO):latest  \
+	             -t $(REPO):$(VERS) \
 	             -t $(REPO):$(HASH) \
 	             -t $(REPO):$(DATE)-$(VERS)-$(HASH) .
-
-push: image
-	docker push $(REPO):$(VERS)
-	docker push $(REPO):$(HASH)
-	docker push $(REPO):$(DATE)-$(VERS)-$(HASH)
 
 release: build test
 	go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
 	git-chglog --next-tag $(VTAG) -o CHANGELOG.md
 	git commit -am "release: $(VTAG)"
 	git tag $(VTAG)
+
+push: image
+	docker push $(REPO):$(VERS)
+	docker push $(REPO):$(HASH)
+	docker push $(REPO):$(DATE)-$(VERS)-$(HASH)
+
+latest:
+	# push the local 'latest' tag as the new public latest version
+	# (run by CI only for releases)
+	docker push $(REPO):latest
 
 clean:
 	-@rm -f $(BIN)


### PR DESCRIPTION
This PR configures the system to update the container `latest` tag on release.

All image builds create a `latest` tag locally, but the specific make target `release` must be run to push it to the repository, such that we can continue to use the other targets for development builds (which use the `tip` tag).

This new target is invoked only by the release workflow, when there is a commit to `main` with a semver tag (release).

Closes #43 