### PR TITLE
Dist

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Test
         run:  make test
       - name: Build
-        run:  make build
+        run:  make cross-platform
       - name: Image
         run:  make image
       - name: Push Image
@@ -26,8 +26,8 @@ jobs:
         run: |
           docker login -u "$USER" -p "$PASS" quay.io 
           make push && make latest
-      - name: Compress Release Binary
-        run: gzip ./faas
+      - name: Compress Binaries
+        run: gzip faas_darwin_amd64 faas_linux_amd64 faas_windows_amd64.exe
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -38,15 +38,30 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Binary
+      - name: Upload Darwin Binary
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./faas.gz
-          asset_name: faas.gz
+          asset_path: ./faas_darwin_amd64.gz
+          asset_name: faas_darwin_amd64.gz
           asset_content_type: application/x-gzip
-
-        # TODO:
-        # - build cross-platform binaries (make release)
+      - name: Upload Linux Binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./faas_linux_amd64.gz
+          asset_name: faas_linux_amd64.gz
+          asset_content_type: application/x-gzip
+      - name: Upload Windows Binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./faas_windows_amd64.exe.gz
+          asset_name: faas_windows_amd64.exe.gz
+          asset_content_type: application/x-gzip

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /faas
+/faas_*
 /templates/go/events/go.sum
 /templates/go/http/go.sum
 node_modules

--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,13 @@ $(BIN): $(CODE)  ## Build using environment defaults
 	go build -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
 
 $(DARWIN):
-	env GOOS=darwin GOARCH=amd64 go build -v -o $(DARWIN) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
+	env GOOS=darwin GOARCH=amd64 go build -o $(DARWIN) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
 
 $(LINUX):
-	env GOOS=linux GOARCH=amd64 go build -v -o $(LINUX) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
+	env GOOS=linux GOARCH=amd64 go build -o $(LINUX) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
 
 $(WINDOWS):
-	env GOOS=windows GOARCH=amd64 go build -v -o $(WINDOWS) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
+	env GOOS=windows GOARCH=amd64 go build -o $(WINDOWS) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
 
 test:
 	go test -cover -coverprofile=coverage.out ./...
@@ -42,12 +42,6 @@ image: Dockerfile
 	             -t $(REPO):$(VERS) \
 	             -t $(REPO):$(HASH) \
 	             -t $(REPO):$(DATE)-$(VERS)-$(HASH) .
-
-release: build test
-	go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
-	git-chglog --next-tag $(VTAG) -o CHANGELOG.md
-	git commit -am "release: $(VTAG)"
-	git tag $(VTAG)
 
 push: image
 	docker push $(REPO):$(VERS)
@@ -64,6 +58,12 @@ bin/golangci-lint:
 
 check: bin/golangci-lint
 	./bin/golangci-lint run --enable=unconvert,prealloc,bodyclose
+
+release: build test
+	go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
+	git-chglog --next-tag $(VTAG) -o CHANGELOG.md
+	git commit -am "release: $(VTAG)"
+	git tag $(VTAG)
 
 clean:
 	rm -f $(WINDOWS) $(LINUX) $(DARWIN)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ VTAG := $(shell git tag --points-at HEAD)
 VERS := $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
 
 build: all
-all: $(LINUX)
+all: $(BIN)
+
 cross-platform: $(DARWIN) $(LINUX) $(WINDOWS)
 
 darwin: $(DARWIN) ## Build for Darwin (macOS)
@@ -20,6 +21,9 @@ darwin: $(DARWIN) ## Build for Darwin (macOS)
 linux: $(LINUX) ## Build for Linux
 
 windows: $(WINDOWS) ## Build for Windows
+
+$(BIN): $(CODE)  ## Build using environment defaults
+	go build -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
 
 $(DARWIN):
 	env GOOS=darwin GOARCH=amd64 go build -v -o $(DARWIN) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
@@ -29,9 +33,6 @@ $(LINUX):
 
 $(WINDOWS):
 	env GOOS=windows GOARCH=amd64 go build -v -o $(WINDOWS) -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
-
-# $(BIN): $(CODE)
-# 	go build -ldflags "-X main.date=$(DATE) -X main.vers=$(VERS) -X main.hash=$(HASH)" ./cmd/$(BIN)
 
 test:
 	go test -cover -coverprofile=coverage.out ./...


### PR DESCRIPTION
Release cross-platform binaries, retaining os-defined environmental settings for the default `make` task for development.  Closes #42 and #53 