### PR TITLE
doc: add docs for configuring a Kind cluster and getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,114 +2,70 @@
 
 [![Main Build Status](https://github.com/boson-project/faas/workflows/Main/badge.svg?branch=main)](https://github.com/boson-project/faas/actions?query=workflow%3AMain+branch%3Amain)
 [![Develop Build Status](https://github.com/boson-project/faas/workflows/Develop/badge.svg?branch=develop&label=develop)](https://github.com/boson-project/faas/actions?query=workflow%3ADevelop+branch%3Adevelop)
-[![Documentation](https://godoc.org/github.com/boson-project/faas?status.svg)](http://godoc.org/github.com/boson-project/faas)
+[![Client API Documentation](https://godoc.org/github.com/boson-project/faas?status.svg)](http://godoc.org/github.com/boson-project/faas)
 [![GitHub Issues](https://img.shields.io/github/issues/boson-project/faas.svg)](https://github.com/boson-project/faas/issues)
 [![License](https://img.shields.io/github/license/boson-project/faas)](https://github.com/boson-project/faas/blob/main/LICENSE)
 [![Release](https://img.shields.io/github/release/boson-project/faas.svg?label=Release)](https://github.com/boson-project/faas/releases)
 
+[Demo Screencast]
 
-Function as a Service CLI and Client Library for KNative-enabled Kubernetes Clusters.
+faas is a "Function as a Service" Client Library and CLI for enabling the development of implicitly deployed, platform agnostic code.
 
-## Local Setup and Configuration
+For examples of what's possible, see the [Screencast Series](docs/getting_started_screencast.md) or the [Functions Cookbook](docs/functions_cookbook.md).
 
-Docker is required unless the --local flag is explicitly provided on creation
-of a new function.
+Functions can be written in the following languages:
 
-It is recommended to set your preferred image registry for publishing Functions
-by setting the following environment variables:
-```
-export FAAS_REGISTRY=quay.io
-export FAAS_NAMESPACE=alice
-```
-Alternately, these values can be provided using the --namespace and --registry 
-flags when running the CLI.
+* Go (Golang)
+* Node.js (JavaScript)
+* Quarkus (Java)
+* Rust
 
-## Cluster Setup and Configuration
+Functions can be deployed on the following platforms:
 
-It is assumed that the local system has a kubectl configuration set up to 
-connect to a Kubernetes cluster with the following configuration:
+* Kubernetes
+* OpenShift
+* Localhost
 
-* Knative Serving and Eventing Installed
-* Knative Domains patched to enable your chosen domain
-* Knative Network patched to enable subdomains
-* Kourier 
-* (optionally) Cert-manager for HTTPS routes
+[Quickstart Video]
 
-See https://github.com/boson-project/config for cluster setup and configuration notes.
+## Client Installation
 
-## Running the CLI
+[Install the latest CLI](docs/installing_cli.md)
 
-The CLI can be run either by building and installing manually, by running
-one of the published containers, or using the appropriate pre-built binary
-releases.
+[Install the VS Code Plugin](docs/installing_vscode.md)
 
-## Build and Install
+[Install the VIM Plugin](docs/installing_vim.md)
 
-With Go 1.13+ installed, build and install the binary to your path:
-```
-go install ./cmd/faas
-```
-### Docker 
+[Install the Emacs Extension](docs/installing_emacs.md)
 
-Each tag has an assoicated container which can be run via:
-```
-docker run quay.io/boson/faas:v0.2.2
-```
+Functions can be created and managed using the CLI interactively, scripted, using one of the IDE plugins, or by direct integration with the client library.   The [Function Developer's Guide](docs/developers_guide.md)and examples herein demonstrate the CLI-based approach.  
 
-### Pre-built Binary Releases
+For direct integration using the Go client library, it is advisible to first follow these CLI-based guides to become familiar with creating and deploying software in this way, and then proceed to the [Function Integrator's Guide](docs/integrators_guide.md).
 
-Coming soon.
+## Platform Configuration
 
-## Usage
+[Getting Started with Kubernetes](docs/getting_started_kubernetes.md)
 
-See help:
-```shell
-faas
-```
-## Examples
+[Getting Started with OpenShift](docs/getting_started_openshift.md)
 
-Create a new Function:
+[Getting Started on Localhost](docs/getting_started_localhost.md)
 
-```shell
-> mkdir -p example.com/www
-> cd example.com/www
-> faas create go
-https://www.example.com
-> curl https://www.example.com
-OK
-```
-## Using the Client Library
+Functions are portable between different infrastructure configurations.  While your Funciton itself remains the same, the platform upon which it is deployed will provide different services and guarantees.  For instance, a Function deployed to localhost will not autoscale, nor be either highly available or externally routable.  Deploying to a properly configured Kubernetes cluster would however provide these features.  There is also variance within infrastrucutre types.  For instance, a small kubernetes cluster will be limited in the amount of resources which will be ultimately available for allocation to your Function. 
 
-To create a Client which uses the included buildpacks-based function builder, pushes to a Quay.io repository function container artifacts and deploys to a Knative enabled cluster: 
-```go
-package main
+## Function Development
 
-import (
-  "log"
+[Function Developer's Guide](docs/developers_guide.md)
 
-  "github.com/boson-project/faas"
-  "github.com/boson-project/faas/buildpacks"
-  "github.com/boson-project/faas/docker"
-  "github.com/boson-project/faas/embedded"
-  "github.com/boson-project/faas/knative"
-)
+Any code which provides one of a set of supported function signatures can be deployed to any of the supported platforms using this client library.  No process boundary code, container, or configuration outside of the function itself is required.
 
-func main() {
-  // A client which uses embedded function templates,
-  // Quay.io/alice for interstitial build artifacts.
-  // Docker to build and push, and a Knative client for deployment.
-  client, err := faas.New(
-    faas.WithInitializer(embedded.NewInitializer("")),
-    faas.WithBuilder(buildpacks.NewBuilder("quay.io", "alice")),
-    faas.WithPusher(docker.NewPusher()),
-    faas.WithDeployer(knative.NewDeployer()))
+At their most fundamental, a Function is a set of instructions which export a public function whose method signature conforms to one of the supported forms.  It is implicitly deployed to a supported platform when created using the client library, and can be migrated between platforms without code changes.  Runtime execution is handled by the platform, which may offer guarantees such as autoscaling and load balancing.  For more, continue with the Developer's Guide
 
-  // Create a Go function which listens for CloudEvents.
-  // Publicly routable as https://www.example.com.
-  // Local implementation is written to the current working directory.
-  if err := client.Create("go", "events", "www.example.com", "."); err != nil {
-    log.Fatal(err)
-  }
-}
-```
+
+## Learn More
+
+[Function Architecture](docs/architecture.md)
+
+## Contributing
+
+We are always looking for contributions from the Function Developer community.  For more information on how to participate, see the [Contributor's Guide](docs/contributors_guide.md)
 

--- a/README.md
+++ b/README.md
@@ -11,59 +11,7 @@
 
 faas is a "Function as a Service" Client Library and CLI for enabling the development of implicitly deployed, platform agnostic code.
 
-For examples of what's possible, see the [Screencast Series](docs/getting_started_screencast.md) or the [Functions Cookbook](docs/functions_cookbook.md).
-
-Functions can be written in the following languages:
-
-* Go (Golang)
-* Node.js (JavaScript)
-* Quarkus (Java)
-* Rust
-
-Functions can be deployed on the following platforms:
-
-* Kubernetes
-* OpenShift
-* Localhost
-
-[Quickstart Video]
-
-## Client Installation
-
-[Install the latest CLI](docs/installing_cli.md)
-
-[Install the VS Code Plugin](docs/installing_vscode.md)
-
-[Install the VIM Plugin](docs/installing_vim.md)
-
-[Install the Emacs Extension](docs/installing_emacs.md)
-
-Functions can be created and managed using the CLI interactively, scripted, using one of the IDE plugins, or by direct integration with the client library.   The [Function Developer's Guide](docs/developers_guide.md)and examples herein demonstrate the CLI-based approach.  
-
-For direct integration using the Go client library, it is advisible to first follow these CLI-based guides to become familiar with creating and deploying software in this way, and then proceed to the [Function Integrator's Guide](docs/integrators_guide.md).
-
-## Platform Configuration
-
-[Getting Started with Kubernetes](docs/getting_started_kubernetes.md)
-
-[Getting Started with OpenShift](docs/getting_started_openshift.md)
-
-[Getting Started on Localhost](docs/getting_started_localhost.md)
-
-Functions are portable between different infrastructure configurations.  While your Funciton itself remains the same, the platform upon which it is deployed will provide different services and guarantees.  For instance, a Function deployed to localhost will not autoscale, nor be either highly available or externally routable.  Deploying to a properly configured Kubernetes cluster would however provide these features.  There is also variance within infrastrucutre types.  For instance, a small kubernetes cluster will be limited in the amount of resources which will be ultimately available for allocation to your Function. 
-
-## Function Development
-
-[Function Developer's Guide](docs/developers_guide.md)
-
-Any code which provides one of a set of supported function signatures can be deployed to any of the supported platforms using this client library.  No process boundary code, container, or configuration outside of the function itself is required.
-
-At their most fundamental, a Function is a set of instructions which export a public function whose method signature conforms to one of the supported forms.  It is implicitly deployed to a supported platform when created using the client library, and can be migrated between platforms without code changes.  Runtime execution is handled by the platform, which may offer guarantees such as autoscaling and load balancing.  For more, continue with the Developer's Guide
-
-
-## Learn More
-
-[Function Architecture](docs/architecture.md)
+[Read the Documentation](docs/README.md)
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [Demo Screencast]
 
-faas is a "Function as a Service" Client Library and CLI for enabling the development of implicitly deployed, platform agnostic code.
+`faas` is a "Function as a Service" Client Library and CLI for enabling the development of implicitly deployed, platform agnostic code.
 
 For examples of what's possible, see the [Screencast Series](getting_started_screencast.md) or the [Functions Cookbook](functions_cookbook.md).
 
@@ -11,7 +11,7 @@ Functions can be written in the following languages:
 * Go (Golang)
 * Node.js (JavaScript)
 * Quarkus (Java)
-* Rust
+* Rust (Coming Soon)
 
 Functions can be deployed on the following platforms:
 
@@ -25,13 +25,15 @@ Functions can be deployed on the following platforms:
 
 [Install the latest CLI](installing_cli.md)
 
+<!-- Plugins coming soon
 [Install the VS Code Plugin](installing_vscode.md)
 
 [Install the VIM Plugin](installing_vim.md)
 
 [Install the Emacs Extension](installing_emacs.md)
+-->
 
-Functions can be created and managed using the CLI interactively, scripted, using one of the IDE plugins, or by direct integration with the client library.   The [Function Developer's Guide](developers_guide.md)and examples herein demonstrate the CLI-based approach.  
+Functions can be created and managed using the CLI interactively, scripted, or by direct integration with the client library.   The [Function Developer's Guide](developers_guide.md)and examples herein demonstrate the CLI-based approach.  
 
 For direct integration using the Go client library, it is advisible to first follow these CLI-based guides to become familiar with creating and deploying software in this way, and then proceed to the [Function Integrator's Guide](integrators_guide.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,60 @@
+# FAAS Documentation
+
+[Demo Screencast]
+
+faas is a "Function as a Service" Client Library and CLI for enabling the development of implicitly deployed, platform agnostic code.
+
+For examples of what's possible, see the [Screencast Series](getting_started_screencast.md) or the [Functions Cookbook](functions_cookbook.md).
+
+Functions can be written in the following languages:
+
+* Go (Golang)
+* Node.js (JavaScript)
+* Quarkus (Java)
+* Rust
+
+Functions can be deployed on the following platforms:
+
+* Kubernetes
+* OpenShift
+* Localhost
+
+[Quickstart Video]
+
+## Client Installation
+
+[Install the latest CLI](installing_cli.md)
+
+[Install the VS Code Plugin](installing_vscode.md)
+
+[Install the VIM Plugin](installing_vim.md)
+
+[Install the Emacs Extension](installing_emacs.md)
+
+Functions can be created and managed using the CLI interactively, scripted, using one of the IDE plugins, or by direct integration with the client library.   The [Function Developer's Guide](developers_guide.md)and examples herein demonstrate the CLI-based approach.  
+
+For direct integration using the Go client library, it is advisible to first follow these CLI-based guides to become familiar with creating and deploying software in this way, and then proceed to the [Function Integrator's Guide](integrators_guide.md).
+
+## Platform Configuration
+
+[Getting Started with Kubernetes](getting_started_kubernetes.md)
+
+[Getting Started with OpenShift](getting_started_openshift.md)
+
+[Getting Started on Localhost](getting_started_localhost.md)
+
+Functions are portable between different infrastructure configurations.  While your Function itself remains the same, the platform upon which it is deployed will provide different services and guarantees.  For instance, a Function deployed to your local host will not autoscale, nor be highly available nor externally routable by default.  Deploying to a properly configured Kubernetes cluster would however provide these features.  There is also variance within infrastrucutre types.  For instance, a small kubernetes cluster will be limited in the amount of resources which will be ultimately available for allocation to your Function.
+
+## Function Development
+
+[Function Developer's Guide](developers_guide.md)
+
+Any code which provides one of a set of supported function signatures can be deployed to any of the supported platforms using this client library.  No process boundary code, container, or configuration outside of the function itself is required.
+
+At their most fundamental, a Function is a set of instructions which export a public function whose method signature conforms to one of the supported forms.  It is implicitly deployed to a supported platform when created using the client library, and can be migrated between platforms without code changes.  Runtime execution is handled by the platform, which may offer guarantees such as autoscaling and load balancing.  
+
+
+## Learn More
+
+[Function Architecture](architecture.md)
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,1 @@
+# Functions Architecture

--- a/docs/contributors_guide.md
+++ b/docs/contributors_guide.md
@@ -1,0 +1,16 @@
+# Contributing
+
+More information coming soon.
+
+## Connecting with the Community
+
+## Picking an Issue
+
+## Style Guide
+
+## Submitting a Pull Request
+
+## Code of Conduct
+
+## Contributor's Agreement
+

--- a/docs/developers_guide.md
+++ b/docs/developers_guide.md
@@ -1,0 +1,40 @@
+# Function Developer's Guide
+
+Before learning to develop Functions, you should have the client installed and a configured provider.
+
+## Local Setup and Configuration
+
+Docker is required unless the --local flag is explicitly provided on creation
+of a new function.
+
+It is recommended to set your preferred image registry for publishing Functions
+by setting the following environment variables:
+```
+export FAAS_REGISTRY=quay.io
+export FAAS_NAMESPACE=alice
+```
+Alternately, when using the CLI these values can be provided using the --namespace and --registry 
+flags.
+
+## Examples
+
+### Create a new Function:
+
+```shell
+> mkdir -p example.com/www
+> cd example.com/www
+> faas create go
+https://www.example.com
+> curl https://www.example.com
+OK
+```
+
+Update a Function:
+
+After
+
+
+### The Grid
+
+Assuming you have followed one of the Getting Started guides, you are now connected to, and have created a new function on, a compatible set of compute resources.  From the perspective of your function, these resources are a utility; much like connecting to the electrical grid.  The basic units of this Compute Grid (henceforth called simply the Grid) is CPU RAM and Disk.  The functions you write will be able to run on any other variant of the infrastrucutre in much the same way as any electrical device can utilize the electrical grid from any provider, with certain caviats such as load and guarantees.
+

--- a/docs/eks/config-cluster.yaml
+++ b/docs/eks/config-cluster.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: prod
+  region: us-west-2
+  version: '1.15'
+
+nodeGroups:
+  - name: workers
+    labels:
+      group: workers
+    instanceType: m5.xlarge
+    desiredCapacity: 1
+    volumeSize: 50
+    ssh:
+      publicKeyPath: keys/ssh.pub
+    iam:
+      attachPolicyARNs:
+        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+

--- a/docs/eks/users.yaml
+++ b/docs/eks/users.yaml
@@ -1,0 +1,8 @@
+# Cluster users
+# Used to patch configmap/aws-auth in the kube-system namespace.
+data:
+  mapUsers: |
+    - userarn: $(USER_ARN)
+      username: $(USERNAME)
+      groups:
+        - system:masters

--- a/docs/functions_cookbook.md
+++ b/docs/functions_cookbook.md
@@ -1,0 +1,5 @@
+# Functions Cookbook
+
+This section contains example function implementations for common use cases, including all those demonstrated in the [Getting Started Screencast](getting_started_screencast.md) series.
+
+

--- a/docs/getting_started_kubernetes.md
+++ b/docs/getting_started_kubernetes.md
@@ -148,10 +148,7 @@ Note that on local clusters such as Kind, it is necessary to add the following a
 Get the installed KNative serving and Eventing versions
 ```
 kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels "serving.knative.dev/release"}}'
-```
-```
 kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels "eventing.knative.dev/release"}}'
 ```
-
 
 

--- a/docs/getting_started_kubernetes.md
+++ b/docs/getting_started_kubernetes.md
@@ -4,6 +4,8 @@ Functions can be deployed to any kubernetes cluster which has been configured to
 
 This guide was developed using the dependency versions listed in their requisite sections.  Instructions may deviate slightly as these projects are generally under active development.  It is recommended to use the links to the official documentation provided in each section.
 
+## Provision a Cluster
+
 Any Kubernetes-compatible API should be capable.  Included herein are instructions for two popular variants: Kind and EKS.
 
 [Provision using Kind](provision_kind.md)
@@ -12,227 +14,18 @@ Any Kubernetes-compatible API should be capable.  Included herein are instructio
 
 [Provision using Amazon EKS](provision_eks.md)
 
-## Provisioning a Kind (Kubernetes in Docker) Cluster
-
-[kind](https://github.com/kubernetes-sigs/kind) is a lightweight tool for running local Kubernetes clusters using containers.  It can be used as the underlying infrastructure for Functions, though it is intended for testing and development rather than production deployment.
-
-This guide walks through the process of configuring a kind cluster to run Functions with the following vserions:
-* kind   v0.8.1 - [Install Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
-* Kubectl v1.17.3 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) 
-
-Start a new cluster:
-```
-kind create cluster
-```
-List available clusters:
-```
-kind get clusters
-```
-List running containers will now show a kind process:
-```
-docker ps
-```
-
-### Connecting Remotely
-
-Kind is intended to be a locally-running service, and exposing externally is not recommended.  However, a fully configured kubernetes cluster can often quickly outstrip the resources available on even a well-specced development workstation.  Therefore, creating a Kind cluster network appliance of sorts can be helpful.  One possible way to connect to your kind cluster remotely would be to create a [wireguard](https://www.wireguard.com/) interface upon which to expose the API.  Following is an example assuming linux hosts with systemd:
-
-First [Install Wireguard](https://www.wireguard.com/install/)
-
-Create keypair for the host and client.
-```
-wg genkey | tee host.key | wg pubkey > host.pub
-wg genkey | tee client.key | wg pubkey > client.pub
-chmod 600 host.key client.key
-```
-Assuming IPv4 addresses, with the wireguard-protected network 10.10.10.0/24, the host being 10.10.10.1 and the client 10.10.10.2
-
-On the host, create a Wireguard Network Device:
-`/etc/systemd/network/99-wg0.netdev`
-```
-[NetDev]
-Name=wg0
-Kind=wireguard
-Description=WireGuard tunnel wg0
-
-[WireGuard]
-ListenPort=51111
-PrivateKey=HOST_KEY
-
-[WireGuardPeer]
-PublicKey=HOST_PUB
-AllowedIPs=10.10.10.0/24
-PersistentKeepalive=25
-```
-(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
-
-`/etc/systemd/network/99-wg0.network`
-```
-[Match]
-Name=wg0
-
-[Network]
-Address=10.10.10.1/24
-```
-
-On the client, create the Wireguard Network Device and Network:
-`/etc/systemd/network/99-wg0.netdev`
-```
-[NetDev]
-Name=wg0
-Kind=wireguard
-Description=WireGuard tunnel wg0
-
-[WireGuard]
-ListenPort=51871
-PrivateKey=CLIENT_KEY
-
-[WireGuardPeer]
-PublicKey=CLIENT_PUB
-AllowedIPs=10.10.10.0/24
-Endpoint=HOST_ADDRESS:51111
-PersistentKeepalive=25
-```
-(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
-
-Replace HOST_ADDRESS with an IP address at which the host can be reached prior to to wireguard interface becoming available.
-
-`/etc/systemd/network/99-wg0.network`
-```
-[Match]
-Name=wg0
-
-[Network]
-Address=10.10.10.2/24
-```
-
-_On both systems_, restrict the permissions of the network device file as it contains sensitive keys, then restart systemd-networkd.
-```
-chown root:systemd-network /etc/systemd/network/99-*.netdev
-chmod 0640 /etc/systemd/network/99-*.netdev
-systemctl restart systemd-networkd
-```
-
-The hosts should now be able to ping each other using their wireguard-protectd 10.10.10.0/24 addresses.  Additionally, statistics about the connection can be obtaned from the `wg` command:
-```
-wg show
-```
-
-Create a Kind configuration file which instructs the API server to listen on the Wireguard interface and a known port:
-`kind-config.yaml`
-```
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  apiServerAddress: "10.10.10.1" # default 127.0.0.1
-  apiServerPort: 6443 # default random, must be different for each cluster
-```
-Delete the current cluster if necessary:
-```
-kind delete cluster --name kind
-```
-
-Start a new cluster using the config:
-```
-kind create cluster --config kind-config.yaml
-```
-
-Export a kubeconfig and move it to the client machine:
-```
-kind export kubeconfig --kubeconfig kind-kubeconfig.yaml
-```
-From the client, confirm that pods can be listed:
-```
-kubectl get po --all-namespaces --kubeconfig kind-kubeconfig.yaml
-```
-
-## Provisioning an EKS (Elastic Kubernetes Service) Cluster
-
-Amazon EKS is a fully managed Kubernetes service suitable for production deoployments.  The below instructions were compiled using the following dependency versions:
-
-* eksctl       v1.15
-* kubernetes   v1.15
-
-[Offical EKS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
-
-### AWS CLI tools
-
-Install Python 3 via system package manager, and the AWS cli tools via pip:
-```
-pip install awscli --upgrade --user
-```
-
-### AWS Account
-
-Install the AWS IAM Authenticator
-https://github.com/kubernetes-sigs/aws-iam-authenticator
-
-Create AWS account(s) via the AWS console:
-
-https://console.aws.amazon.com/
-
-Users _of_ the cluster require no permissions at this point, but the user _creating_ the cluster does.  Once configured, set the local environment variables:
-```
-AWS_REGION=us-east-2
-AWS_SECRET_ACCESS_KEY=[redacted]
-AWS_ACCESS_KEY_ID=[redacted]
-```
-
-Or use aws credentials.  To configure the CLI to use credintials, for instance:
-
-To `~/.aws/config` append:
-
-```
-[profile alice]
-region = us-west-2
-output = json
-```
-
-To `~/.aws/credentials` append:
-
-```
-[alice]
-aws_access_key_id = [redacted]
-aws_secret_access_key = [redacted]
-```
-
-The profile to use can then be configured using the environment varaible:
-
-AWS_PROFILE=alice
-
-(note that [direnv](https://direnv.net/) can be handy here.)
-
-### SSH key
-
-Generate cluster SSH key, saving into `./keys/ssh`
-```
-ssh-keygen -t rsa -b 4096
-```
-
-### Cluster Resources
-
-Install `eksctl`
-https://github.com/weaveworks/eksctl
-
-Provision the cluster using `eksctl`.  For example, the configuration file `./eks/cluster-config.yaml` will create a single-node cluster named "prod" in the "us-west-2" region if used:
-```
-eksctl create cluster -f eks/config-cluster.yaml
-```
-
-### Verify Cluster Provisioned
-
-You should be able to retrieve nodes from the cluster
-```
-kubectl get po --all-namespaces
-```
-
-### Administration
-
-See the [eksctl](https://eksctl.io) documentation for how to adminster a cluster, such as [cluster upgrades](https://eksctl.io/usage/cluster-upgrade/) using this helper CLI.
-
 ## Configuring the Cluster
 
 Once access to a kubernetes-compatible cluster has been established, it will need to be configured to handle Function workloads.  This includes Knative Serving and Eventing, the Kourier networking layer, and CertManager with the LetsEncrypt certificate provider.
+
+Create a namespace for your Functions:
+```
+kubectl create namespace faas
+```
+Optionally set the default namespace for kubetl commands:
+```
+kubectl config set-context --current --namespace=faas
+```
 
 ### Serving
 
@@ -253,7 +46,11 @@ Update the networking layer to
 kubectl apply -f knative/config-network.yaml
 ```
 
-Note: for environments where Load Balancers are not supported (such as local Kind clusters), the Kourier service should be updated to be of type IP instead of LoadBalancer.
+Note: for environments where Load Balancers are not supported (such as local Kind or Minikube clusters), the Kourier service should be updated to be of type IP instead of LoadBalancer.  This configuration patches the kourier service to be of type NodePort with its networking service attached to the host at ports HTTP 30080 and HTTPS 30443.
+```
+kubectl patch -n kourier-system services/kourier -p "$(cat knative/config-kourier-nodeport.yaml)"
+```
+For bare metal clusters, installing the [MetalLB LoadBalancer](https://metallb.universe.tf/) is also an option.
 
 ### Domains
 
@@ -270,74 +67,88 @@ Register domain(s) to be used, configuring a CNAME to the DNS or IP returned fro
 ```
 kubectl --namespace kourier-system get service kourier
 ```
-May register a wildcard matching subdomain, for example.
-
-### Users
-
-Install users:
-```
-kubectl patch -n kube-system configmap/aws-auth --patch "$(cat users.yaml)"
-```
+May also register a wildcard subdomain match.
 
 ### TLS
 
-Assumed Cert Manager configured to use Letsencrypt production and CloudFlare for DNS.
+In order to provision HTTPS routes, we optionally set up a Certificate Manager for the cluster.  In this example we configure it to use LetsEncrypt certificates vi a certificate provider and CloudFlare as the DNS provider.
 
-Install Cert-manager
+#### Cert-Manager
 
 Docs: https://cert-manager.io/docs/installation/kubernetes/
 ```
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.3/cert-manager.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.0/cert-manager.yaml
+```
+Create a Cluster Issuer by updating `tls/letsencrypt-issuer.yaml` with an email addresses for the LetsEncrypt registration and for the associated CloudFlare account:
+```
+kubectl apply -f tls/letsencrypt-issuer.yaml
+```
+Generate a token with CloudFlare with the following settings:
+* Permission: Zone - Zone - Read
+* Permission: Zone - DNS - Edit
+* Zone Resources: Include - All ZOnes
+
+Base64 encode the token:
+```
+echo -n 'CLOUDFLARE_TOKEN' | base64
+```
+Update the `tls/cloudflare-secret.yaml` with the base64-encoded token value and create the secret:
+```
+kubectl apply -f tls/cloudflare-secret.yaml
 ```
 
-Create a Cluster Issuer, update cluster-issuer.yaml with email address, and create the associated cloudflare secret.
+#### KNative Serving Cert-Manager Integration
+
+Install the latest networking certmanager packaged with KNative Serving:
+Docs: https://knative.dev/docs/serving/using-auto-tls/
+
 ```
-kubectl apply -f cluster-issuer.yaml
+kubectl apply --filename https://github.com/knative/net-certmanager/releases/download/v0.16.0/release.yaml
 ```
-The secret should be a CloudFlare Token with Zone Read and DNS Write permissions, in the UI as:
-```
-Zone -> Zone -> Read
-Zone -> DNS -> Edit
-```
-```
-kubectl apply -f secrets/cloudflare.yaml
-```
-Install the latest networking certmanager:
-```
-kubectl apply --filename https://github.com/knative/serving/releases/download/v0.13.0/serving-cert-manager.yaml
-```
-Edit config-certmanager to reference the letsencrypt issuer:
+Edit config-certmanager to reference the letsencrypt issuer.  There should be an issuerRef pointing to a ClusterIssuer of name `letsencrypt-issuer`:
 ```
 kubectl edit configmap config-certmanager --namespace knative-serving
 ```
-
 
 ### Eventing
 
 Eventing with In-memory channels, a Channel broker, and enable the default broker in the faas namespace.
 ```
-kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/eventing-crds.yaml
-kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/eventing-core.yaml
-kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/in-memory-channel.yaml
-kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/channel-broker.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.16.0/eventing-crds.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.16.0/eventing-core.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.16.0/in-memory-channel.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.16.0/mt-channel-broker.yaml
 ```
-Enable Broker for faas namespace and install GitHub source:
+GitHub events source:
 ```
-kubectl create namespace faas
-kubectl label namespace faas knative-eventing-injection=enabled
-kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.13.0/github.yaml
+kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.16.0/github.yaml
 ```
 Learn more about the Github source at https://knative.dev/docs/eventing/samples/github-source/index.html
 
+Enable Broker for faas namespace:
+```
+kubectl label namespace faas knative-eventing-injection=enabled
+```
 
-### Other
+### Monitoring
 
-Get serving version
+Optionally the addition of the [metrics-server](https://github.com/kubernetes-sigs/metrics-server) API allows one to run `kubectl top nodes` and `kubectl top pods`.  It can be installed with:
+```
+kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
+```
+Note that on local clusters such as Kind, it is necessary to add the following arguments to the metrics-server deployment in kube-system:
+```
+    args:
+        - --kubelet-insecure-tls
+        - --kubelet-preferred-address-types=InternalIP
+```
+
+### Troubleshooting
+
+Get the installed KNative serving and Eventing versions
 ```
 kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels "serving.knative.dev/release"}}'
 ```
-
-Get eventing version
 ```
 kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels "eventing.knative.dev/release"}}'
 ```

--- a/docs/getting_started_kubernetes.md
+++ b/docs/getting_started_kubernetes.md
@@ -6,10 +6,11 @@ This guide was developed using the dependency versions listed in their requisite
 
 Any Kubernetes-compatible API should be capable.  Included herein are instructions for two popular variants: Kind and EKS.
 
-## Local dependencies
+[Provision using Kind](provision_kind.md)
 
-This guide assumes the following local shared dependncies:
-* Kubectl v1.17.3 - [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) 
+[Provision using Minikube](provision_minikube.md)
+
+[Provision using Amazon EKS](provision_eks.md)
 
 ## Provisioning a Kind (Kubernetes in Docker) Cluster
 
@@ -17,6 +18,7 @@ This guide assumes the following local shared dependncies:
 
 This guide walks through the process of configuring a kind cluster to run Functions with the following vserions:
 * kind   v0.8.1 - [Install Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+* Kubectl v1.17.3 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) 
 
 Start a new cluster:
 ```

--- a/docs/getting_started_kubernetes.md
+++ b/docs/getting_started_kubernetes.md
@@ -1,0 +1,344 @@
+# Getting Started with Kubernetes
+
+Functions can be deployed to any kubernetes cluster which has been configured to support function workloads.  This guide details how to set up and configure a kubernetes cluster accordingly.
+
+This guide was developed using the dependency versions listed in their requisite sections.  Instructions may deviate slightly as these projects are generally under active development.  It is recommended to use the links to the official documentation provided in each section.
+
+Any Kubernetes-compatible API should be capable.  Included herein are instructions for two popular variants: Kind and EKS.
+
+## Local dependencies
+
+This guide assumes the following local shared dependncies:
+* Kubectl v1.17.3 - [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) 
+
+## Provisioning a Kind (Kubernetes in Docker) Cluster
+
+[kind](https://github.com/kubernetes-sigs/kind) is a lightweight tool for running local Kubernetes clusters using containers.  It can be used as the underlying infrastructure for Functions, though it is intended for testing and development rather than production deployment.
+
+This guide walks through the process of configuring a kind cluster to run Functions with the following vserions:
+* kind   v0.8.1 - [Install Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+Start a new cluster:
+```
+kind create cluster
+```
+List available clusters:
+```
+kind get clusters
+```
+List running containers will now show a kind process:
+```
+docker ps
+```
+
+### Connecting Remotely
+
+Kind is intended to be a locally-running service, and exposing externally is not recommended.  However, a fully configured kubernetes cluster can often quickly outstrip the resources available on even a well-specced development workstation.  Therefore, creating a Kind cluster network appliance of sorts can be helpful.  One possible way to connect to your kind cluster remotely would be to create a [wireguard](https://www.wireguard.com/) interface upon which to expose the API.  Following is an example assuming linux hosts with systemd:
+
+First [Install Wireguard](https://www.wireguard.com/install/)
+
+Create keypair for the host and client.
+```
+wg genkey | tee host.key | wg pubkey > host.pub
+wg genkey | tee client.key | wg pubkey > client.pub
+chmod 600 host.key client.key
+```
+Assuming IPv4 addresses, with the wireguard-protected network 10.10.10.0/24, the host being 10.10.10.1 and the client 10.10.10.2
+
+On the host, create a Wireguard Network Device:
+`/etc/systemd/network/99-wg0.netdev`
+```
+[NetDev]
+Name=wg0
+Kind=wireguard
+Description=WireGuard tunnel wg0
+
+[WireGuard]
+ListenPort=51111
+PrivateKey=HOST_KEY
+
+[WireGuardPeer]
+PublicKey=HOST_PUB
+AllowedIPs=10.10.10.0/24
+PersistentKeepalive=25
+```
+(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
+
+`/etc/systemd/network/99-wg0.network`
+```
+[Match]
+Name=wg0
+
+[Network]
+Address=10.10.10.1/24
+```
+
+On the client, create the Wireguard Network Device and Network:
+`/etc/systemd/network/99-wg0.netdev`
+```
+[NetDev]
+Name=wg0
+Kind=wireguard
+Description=WireGuard tunnel wg0
+
+[WireGuard]
+ListenPort=51871
+PrivateKey=CLIENT_KEY
+
+[WireGuardPeer]
+PublicKey=CLIENT_PUB
+AllowedIPs=10.10.10.0/24
+Endpoint=HOST_ADDRESS:51111
+PersistentKeepalive=25
+```
+(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
+
+Replace HOST_ADDRESS with an IP address at which the host can be reached prior to to wireguard interface becoming available.
+
+`/etc/systemd/network/99-wg0.network`
+```
+[Match]
+Name=wg0
+
+[Network]
+Address=10.10.10.2/24
+```
+
+_On both systems_, restrict the permissions of the network device file as it contains sensitive keys, then restart systemd-networkd.
+```
+chown root:systemd-network /etc/systemd/network/99-*.netdev
+chmod 0640 /etc/systemd/network/99-*.netdev
+systemctl restart systemd-networkd
+```
+
+The hosts should now be able to ping each other using their wireguard-protectd 10.10.10.0/24 addresses.  Additionally, statistics about the connection can be obtaned from the `wg` command:
+```
+wg show
+```
+
+Create a Kind configuration file which instructs the API server to listen on the Wireguard interface and a known port:
+`kind-config.yaml`
+```
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "10.10.10.1" # default 127.0.0.1
+  apiServerPort: 6443 # default random, must be different for each cluster
+```
+Delete the current cluster if necessary:
+```
+kind delete cluster --name kind
+```
+
+Start a new cluster using the config:
+```
+kind create cluster --config kind-config.yaml
+```
+
+Export a kubeconfig and move it to the client machine:
+```
+kind export kubeconfig --kubeconfig kind-kubeconfig.yaml
+```
+From the client, confirm that pods can be listed:
+```
+kubectl get po --all-namespaces --kubeconfig kind-kubeconfig.yaml
+```
+
+## Provisioning an EKS (Elastic Kubernetes Service) Cluster
+
+Amazon EKS is a fully managed Kubernetes service suitable for production deoployments.  The below instructions were compiled using the following dependency versions:
+
+* eksctl       v1.15
+* kubernetes   v1.15
+
+[Offical EKS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+
+### AWS CLI tools
+
+Install Python 3 via system package manager, and the AWS cli tools via pip:
+```
+pip install awscli --upgrade --user
+```
+
+### AWS Account
+
+Install the AWS IAM Authenticator
+https://github.com/kubernetes-sigs/aws-iam-authenticator
+
+Create AWS account(s) via the AWS console:
+
+https://console.aws.amazon.com/
+
+Users _of_ the cluster require no permissions at this point, but the user _creating_ the cluster does.  Once configured, set the local environment variables:
+```
+AWS_REGION=us-east-2
+AWS_SECRET_ACCESS_KEY=[redacted]
+AWS_ACCESS_KEY_ID=[redacted]
+```
+
+Or use aws credentials.  To configure the CLI to use credintials, for instance:
+
+To `~/.aws/config` append:
+
+```
+[profile alice]
+region = us-west-2
+output = json
+```
+
+To `~/.aws/credentials` append:
+
+```
+[alice]
+aws_access_key_id = [redacted]
+aws_secret_access_key = [redacted]
+```
+
+The profile to use can then be configured using the environment varaible:
+
+AWS_PROFILE=alice
+
+(note that [direnv](https://direnv.net/) can be handy here.)
+
+### SSH key
+
+Generate cluster SSH key, saving into `./keys/ssh`
+```
+ssh-keygen -t rsa -b 4096
+```
+
+### Cluster Resources
+
+Install `eksctl`
+https://github.com/weaveworks/eksctl
+
+Provision the cluster using `eksctl`.  For example, the configuration file `./eks/cluster-config.yaml` will create a single-node cluster named "prod" in the "us-west-2" region if used:
+```
+eksctl create cluster -f eks/config-cluster.yaml
+```
+
+### Verify Cluster Provisioned
+
+You should be able to retrieve nodes from the cluster
+```
+kubectl get po --all-namespaces
+```
+
+### Administration
+
+See the [eksctl](https://eksctl.io) documentation for how to adminster a cluster, such as [cluster upgrades](https://eksctl.io/usage/cluster-upgrade/) using this helper CLI.
+
+## Configuring the Cluster
+
+Once access to a kubernetes-compatible cluster has been established, it will need to be configured to handle Function workloads.  This includes Knative Serving and Eventing, the Kourier networking layer, and CertManager with the LetsEncrypt certificate provider.
+
+### Serving
+
+Docs: https://knative.dev/docs/install/any-kubernetes-cluster/ ) 
+
+Serving with Kourier networking
+```
+kubectl apply --filename https://github.com/knative/serving/releases/download/v0.16.0/serving-crds.yaml
+kubectl apply --filename https://github.com/knative/serving/releases/download/v0.16.0/serving-core.yaml
+kubectl apply --filename https://github.com/knative/net-kourier/releases/download/v0.16.0/kourier.yaml
+```
+Update the networking layer to
+- Use Kourier
+- use TLS
+- Redirect HTTP requests to HTTPS
+- Add faas subdomain annotations
+```
+kubectl apply -f knative/config-network.yaml
+```
+
+Note: for environments where Load Balancers are not supported (such as local Kind clusters), the Kourier service should be updated to be of type IP instead of LoadBalancer.
+
+### Domains
+
+Configure cluster-wide domain TLD+1 by editing k8s/config-domain.yaml to include supported domains.
+Update the `knative/config-domain.yaml` to contain your domain of choice and then apply:
+```
+kubectl apply -f knative/config-domain.yaml
+```
+Note that this step is [pending automation](https://github.com/boson-project/faas/issues/47)
+
+### DNS 
+
+Register domain(s) to be used, configuring a CNAME to the DNS or IP returned from:
+```
+kubectl --namespace kourier-system get service kourier
+```
+May register a wildcard matching subdomain, for example.
+
+### Users
+
+Install users:
+```
+kubectl patch -n kube-system configmap/aws-auth --patch "$(cat users.yaml)"
+```
+
+### TLS
+
+Assumed Cert Manager configured to use Letsencrypt production and CloudFlare for DNS.
+
+Install Cert-manager
+
+Docs: https://cert-manager.io/docs/installation/kubernetes/
+```
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.3/cert-manager.yaml
+```
+
+Create a Cluster Issuer, update cluster-issuer.yaml with email address, and create the associated cloudflare secret.
+```
+kubectl apply -f cluster-issuer.yaml
+```
+The secret should be a CloudFlare Token with Zone Read and DNS Write permissions, in the UI as:
+```
+Zone -> Zone -> Read
+Zone -> DNS -> Edit
+```
+```
+kubectl apply -f secrets/cloudflare.yaml
+```
+Install the latest networking certmanager:
+```
+kubectl apply --filename https://github.com/knative/serving/releases/download/v0.13.0/serving-cert-manager.yaml
+```
+Edit config-certmanager to reference the letsencrypt issuer:
+```
+kubectl edit configmap config-certmanager --namespace knative-serving
+```
+
+
+### Eventing
+
+Eventing with In-memory channels, a Channel broker, and enable the default broker in the faas namespace.
+```
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/eventing-crds.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/eventing-core.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/in-memory-channel.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.13.0/channel-broker.yaml
+```
+Enable Broker for faas namespace and install GitHub source:
+```
+kubectl create namespace faas
+kubectl label namespace faas knative-eventing-injection=enabled
+kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.13.0/github.yaml
+```
+Learn more about the Github source at https://knative.dev/docs/eventing/samples/github-source/index.html
+
+
+### Other
+
+Get serving version
+```
+kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels "serving.knative.dev/release"}}'
+```
+
+Get eventing version
+```
+kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels "eventing.knative.dev/release"}}'
+```
+
+
+

--- a/docs/getting_started_localhost.md
+++ b/docs/getting_started_localhost.md
@@ -1,0 +1,10 @@
+# Getting Started on Localhost
+
+Functions can also be deployed to single-node hosts directly, either for local development, testing, or simply for smaller production deployments.
+
+## Provisioning
+
+The node can be any host which can run containers.  This document assumes a linux host which can run containers.
+
+More coming soon.
+

--- a/docs/getting_started_openshift.md
+++ b/docs/getting_started_openshift.md
@@ -1,0 +1,30 @@
+# Getting Started with OpenShift
+
+Coming Soon
+
+
+## Provisioning
+
+### Licensed OpenShift
+
+Coming Soon.
+
+### CRC (Code-Ready Containers)
+
+CRC is a VM-based OpenShift suitable for testing and development.
+
+See [Installing CRC] for mor information.
+
+### OKD
+
+OKD is the upstream OpenShift distribution.
+
+
+## Configuration
+
+Install the Serverless Operator from the Marketplace
+
+## Validation
+
+## Administration
+

--- a/docs/getting_started_screencast.md
+++ b/docs/getting_started_screencast.md
@@ -1,0 +1,3 @@
+# Getting Started Screencast Series
+
+This section will contain the full getting started screencast series, which proceeds from simple use cases through to complex.

--- a/docs/installing_cli.md
+++ b/docs/installing_cli.md
@@ -1,0 +1,29 @@
+# Installing the CLI
+
+The CLI can be used to invoke most features of the FaaS system.  One can choose to run the container, install one of the pre-built binaries, or compile from source.
+
+### Container
+
+The latest release can be run as a container:
+```
+docker run quay.io/boson/faas
+```
+To run a specific version of the CLI, use the version desired as the image tag:
+```
+docker run quay.io/boson/faas:v0.5.0
+```
+
+### Prebuilt Binary
+
+Download the latest binary appropriate for your system from the [Latest Release](https://github.com/boson-project/faas/releases/latest/).
+
+Each version is built and made available as a prebuilt binary.  See [All Releases](https://github.com/boson-project/faas/releases/).
+
+### From Source
+
+
+To build and install from source check out the repository, run `make`, and install the resultant binary:
+```
+make
+mv faas /usr/local/bin/
+```

--- a/docs/installing_cli.md
+++ b/docs/installing_cli.md
@@ -27,3 +27,4 @@ To build and install from source check out the repository, run `make`, and insta
 make
 mv faas /usr/local/bin/
 ```
+

--- a/docs/installing_emacs.md
+++ b/docs/installing_emacs.md
@@ -1,0 +1,1 @@
+# Installing the Emacs Plugin

--- a/docs/installing_vim.md
+++ b/docs/installing_vim.md
@@ -1,0 +1,1 @@
+# Installing the VIM Plugin

--- a/docs/installing_vscode.md
+++ b/docs/installing_vscode.md
@@ -1,0 +1,1 @@
+# Installing the VS Code Plugin

--- a/docs/integrators_guide.md
+++ b/docs/integrators_guide.md
@@ -1,0 +1,41 @@
+# Integrator's Guide
+
+Developer's can integrate directly with the Function system using the client library upon which the `faas` CLI is based.  Before beginning this section, you should have a configured provider and be familiar with the topics covered in the [developer's guide](docs/developers_guide.md).
+
+## Using the Client Library
+
+To create a Client which uses the included buildpacks-based function builder, pushes to a Quay.io repository function container artifacts and deploys to a Knative enabled cluster: 
+```go
+package main
+
+import (
+  "log"
+
+  "github.com/boson-project/faas"
+  "github.com/boson-project/faas/buildpacks"
+  "github.com/boson-project/faas/docker"
+  "github.com/boson-project/faas/embedded"
+  "github.com/boson-project/faas/knative"
+)
+
+func main() {
+  // A client which uses embedded function templates,
+  // Quay.io/alice for interstitial build artifacts.
+  // Docker to build and push, and a Knative client for deployment.
+  client, err := faas.New(
+    faas.WithInitializer(embedded.NewInitializer("")),
+    faas.WithBuilder(buildpacks.NewBuilder("quay.io", "alice")),
+    faas.WithPusher(docker.NewPusher()),
+    faas.WithDeployer(knative.NewDeployer()))
+
+  // Create a Go function which listens for CloudEvents.
+  // Publicly routable as https://www.example.com.
+  // Local implementation is written to the current working directory.
+  if err := client.Create("go", "events", "www.example.com", "."); err != nil {
+    log.Fatal(err)
+  }
+}
+```
+
+
+

--- a/docs/integrators_guide.md
+++ b/docs/integrators_guide.md
@@ -24,14 +24,14 @@ func main() {
   // Docker to build and push, and a Knative client for deployment.
   client, err := faas.New(
     faas.WithInitializer(embedded.NewInitializer("")),
-    faas.WithBuilder(buildpacks.NewBuilder("quay.io", "alice")),
+    faas.WithBuilder(buildpacks.NewBuilder("quay.io/alice/my-function")),
     faas.WithPusher(docker.NewPusher()),
     faas.WithDeployer(knative.NewDeployer()))
 
   // Create a Go function which listens for CloudEvents.
   // Publicly routable as https://www.example.com.
   // Local implementation is written to the current working directory.
-  if err := client.Create("go", "events", "www.example.com", "."); err != nil {
+  if err := client.Create("go", "events", "my-function", "quay.io/alice/my-function:v1.0"); err != nil {
     log.Fatal(err)
   }
 }

--- a/docs/kind/config-local.yaml
+++ b/docs/kind/config-local.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: worker
+  extraPortMappings:
+  - containerPort: 30080
+    hostPort: 80
+    listenAddress: "0.0.0.0"
+  - containerPort: 30443
+    hostPort: 443
+    listenAddress: "0.0.0.0"

--- a/docs/kind/config-remote.yaml
+++ b/docs/kind/config-remote.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  apiServerAddress: "10.10.10.1" # default 127.0.0.1
+  apiServerPort: 6443 # default random, must be different for each cluster
+nodes:
+- role: control-plane
+- role: worker
+  extraPortMappings:
+  - containerPort: 30080
+    hostPort: 80
+    listenAddress: "0.0.0.0"
+  - containerPort: 30443
+    hostPort: 443
+    listenAddress: "0.0.0.0"

--- a/docs/kind/config.yaml
+++ b/docs/kind/config.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "10.10.10.1" # default 127.0.0.1
+  apiServerPort: 6443 # default random, must be different for each cluster
+nodes:
+- role: control-plane
+- role: worker
+

--- a/docs/kind/config.yaml
+++ b/docs/kind/config.yaml
@@ -1,9 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-networking:
-  apiServerAddress: "10.10.10.1" # default 127.0.0.1
-  apiServerPort: 6443 # default random, must be different for each cluster
-nodes:
-- role: control-plane
-- role: worker
-

--- a/docs/knative/config-domain.yaml
+++ b/docs/knative/config-domain.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+data:
+  # TODO: update this list automatically as Service Functions
+  # are added with differing domains.  For now manually add
+  # one entry per TLD+1.  Example:
+  example.com: |
+    selector:
+      faas.domain: "example.com"
+  example.org: |
+    selector:
+      faas.domain: "example.org"
+  # Default is local only.
+  svc.cluster.local: ""

--- a/docs/knative/config-domain.yaml
+++ b/docs/knative/config-domain.yaml
@@ -7,11 +7,11 @@ data:
   # TODO: update this list automatically as Service Functions
   # are added with differing domains.  For now manually add
   # one entry per TLD+1.  Example:
-  example.com: |
+  boson-project.com: |
     selector:
-      faas.domain: "example.com"
-  example.org: |
+      faas.domain: "boson-project.com"
+  boson-project.org: |
     selector:
-      faas.domain: "example.org"
+      faas.domain: "boson-project.org"
   # Default is local only.
   svc.cluster.local: ""

--- a/docs/knative/config-kourier-nodeport.yaml
+++ b/docs/knative/config-kourier-nodeport.yaml
@@ -1,9 +1,9 @@
 # Patch for changing kourier to a NodePort for installations where a 
-# LoadBalancer is not available (for example local Minikube or Kind clusters)
+# LoadBalancer is not available (for example local Kind clusters)
 spec:
   ports:
   - name: http2
-    nodePort: 32080
+    nodePort: 30080
     port: 80
     protocol: TCP
     targetPort: 8080

--- a/docs/knative/config-kourier-nodeport.yaml
+++ b/docs/knative/config-kourier-nodeport.yaml
@@ -1,0 +1,15 @@
+# Patch for changing kourier to a NodePort for installations where a 
+# LoadBalancer is not available (for example local Minikube or Kind clusters)
+spec:
+  ports:
+  - name: http2
+    nodePort: 32080
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: https
+    nodePort: 30443
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  type: NodePort

--- a/docs/knative/config-network.yaml
+++ b/docs/knative/config-network.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+data:
+  # Use Kourier for the networking layer
+  ingress.class: kourier.ingress.networking.knative.dev
+  # Enable AutoTLS
+  autoTLS: Enabled
+  # Redirect HTTP requests to HTTPS
+  httpProtocol: Redirected
+  # If there exists an annotation `faas.subdomain` on the service,
+  # use it instead of the default name.namespace
+  domainTemplate: |-
+    {{if index .Annotations "faas.subdomain" -}}
+      {{- index .Annotations "faas.subdomain" -}}
+    {{else -}}
+      {{- .Name}}.{{.Namespace -}}
+    {{end -}}
+    .{{.Domain}}

--- a/docs/provision_eks.md
+++ b/docs/provision_eks.md
@@ -1,0 +1,91 @@
+# Provisioning an Amazon EKS (Elastic Kubernetes Service) Cluster
+
+Amazon EKS is a fully managed Kubernetes service suitable for production deoployments.  The below instructions were compiled using the following dependency versions:
+
+* eksctl       v1.15
+* kubernetes   v1.15
+
+[Offical EKS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html)
+
+## AWS CLI tools
+
+Install Python 3 via system package manager, and the AWS cli tools via pip:
+```
+pip install awscli --upgrade --user
+```
+
+## AWS Account
+
+Install the AWS IAM Authenticator
+https://github.com/kubernetes-sigs/aws-iam-authenticator
+
+Create AWS account(s) via the AWS console:
+
+https://console.aws.amazon.com/
+
+Users _of_ the cluster require no permissions at this point, but the user _creating_ the cluster does.  Once configured, set the local environment variables:
+```
+AWS_REGION=us-east-2
+AWS_SECRET_ACCESS_KEY=[redacted]
+AWS_ACCESS_KEY_ID=[redacted]
+```
+
+Or use aws credentials.  To configure the CLI to use credintials, for instance:
+
+To `~/.aws/config` append:
+
+```
+[profile alice]
+region = us-west-2
+output = json
+```
+
+To `~/.aws/credentials` append:
+
+```
+[alice]
+aws_access_key_id = [redacted]
+aws_secret_access_key = [redacted]
+```
+
+The profile to use can then be configured using the environment varaible:
+
+AWS_PROFILE=alice
+
+(note that [direnv](https://direnv.net/) can be handy here.)
+
+## SSH key
+
+Generate cluster SSH key, saving into `./keys/ssh`
+```
+ssh-keygen -t rsa -b 4096
+```
+
+## Cluster Resources
+
+Install `eksctl`
+https://github.com/weaveworks/eksctl
+
+Provision the cluster using `eksctl`.  For example, the configuration file `./eks/cluster-config.yaml` will create a single-node cluster named "prod" in the "us-west-2" region if used:
+```
+eksctl create cluster -f eks/config-cluster.yaml
+```
+
+## Users
+
+Install users by modifying the template to include the ARN and username of the IAM users to give access to the cluster:
+```
+kubectl patch -n kube-system configmap/aws-auth --patch "$(cat eks/users.yaml)"
+```
+
+## Verify Cluster Provisioned
+
+You should be able to retrieve nodes from the cluster, which should include coredns, kube-proxy, etc.
+```
+kubectl get po --all-namespaces
+```
+
+## Administration
+
+See the [eksctl](https://eksctl.io) documentation for how to adminster a cluster, such as [cluster upgrades](https://eksctl.io/usage/cluster-upgrade/) using this helper CLI.
+

--- a/docs/provision_kind.md
+++ b/docs/provision_kind.md
@@ -43,9 +43,10 @@ wg genkey | tee host.key | wg pubkey > host.pub
 wg genkey | tee client.key | wg pubkey > client.pub
 chmod 600 host.key client.key
 ```
+
 Assuming IPv4 addresses, with the wireguard-protected network 10.10.10.0/24, the host being 10.10.10.1 and the client 10.10.10.2
 
-Create a Wireguard Network Device on both the Host and the Client using the following configuration files (Replace HOST_KEY HOST_PUB, CLIENT_KEY and CLIENT_PUB with the keypairs created in the previous step):
+For linux hosts running systemd, create a Wireguard Network Device on both the Host and the Client using the following configuration files (Replace HOST_KEY HOST_PUB, CLIENT_KEY and CLIENT_PUB with the keypairs created in the previous step).  For OS X Clients, skip the client configuration and see the section on OS X below.
 
 On the Kind cluster host:
 `/etc/systemd/network/99-wg0.netdev`
@@ -74,7 +75,7 @@ Name=wg0
 Address=10.10.10.1/24
 ```
 
-On the client:
+On a client (For OS X, see below):
 
 `/etc/systemd/network/99-wg0.netdev`
 ```
@@ -114,6 +115,20 @@ The nodes should now be able to ping each other using their wireguard-protected 
 ```
 wg show
 ```
+For OS X hosts, skip the aforementioned systemd configuraiton, and instead install the Wireguard app from the App store, and then import the following configuration file.
+```
+[Interface]
+Address=10.10.10.2/32
+ListenPort=51871
+PrivateKey=CLIENT_KEY
+
+[Peer]
+PublicKey=HOST_PUB
+AllowedIPs=10.10.10.0/24
+Endpoint=HOST_ADDRESS:51111
+PersistentKeepalive=25
+```
+Note that in order to import the config, it should be in a file with 0600 permissions and the .conf suffix.
 
 ### Provision the Cluster
 
@@ -124,7 +139,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerAddress: "10.10.10.1" # default is 127.0.0.1 (local only)
-  apiServerPort: 6443 # default is random. Note this must be unique per cluster.
+  apiServerPort: 6443            # default is random. 
 ```
 
 Delete the current cluster if necessary:
@@ -145,7 +160,7 @@ kubectl get po --all-namespaces --kubeconfig kind-kubeconfig.yaml
 ```
 ### Verify Cluster Provisioned
 
-You should be able to retrieve nodes from the cluster, which should include coredns, kube-proxy, etc.
+You should be able to retrieve a pods list from the cluster, which should include coredns, kube-proxy, etc.
 ```
 kubectl get po --all-namespaces
 ```

--- a/docs/provision_kind.md
+++ b/docs/provision_kind.md
@@ -20,15 +20,22 @@ List running containers will now show a kind process:
 ```
 docker ps
 ```
+Confirm core services are running:
+```
+kubectl get po --all-namespaces
+```
+You should see
 
-## Configure Remotely
+
+## Configure With Remote Access
 
 This section is optional.
 
 Kind is intended to be a locally-running service, and exposing externally is not recommended.  However, a fully configured kubernetes cluster can often quickly outstrip the resources available on even a well-specd development workstation.  Therefore, creating a Kind cluster network appliance of sorts can be helpful.  One possible way to connect to your kind cluster remotely would be to create a [wireguard](https://www.wireguard.com/) interface upon which to expose the API.  Following is an example assuming linux hosts with systemd:
 
+### Create a Secure Tunnel
 
-First [Install Wireguard](https://www.wireguard.com/install/)
+[Install Wireguard](https://www.wireguard.com/install/)
 
 Create keypair for the host and client.
 ```
@@ -38,7 +45,9 @@ chmod 600 host.key client.key
 ```
 Assuming IPv4 addresses, with the wireguard-protected network 10.10.10.0/24, the host being 10.10.10.1 and the client 10.10.10.2
 
-On the host, create a Wireguard Network Device:
+Create a Wireguard Network Device on both the Host and the Client using the following configuration files (Replace HOST_KEY HOST_PUB, CLIENT_KEY and CLIENT_PUB with the keypairs created in the previous step):
+
+On the Kind cluster host:
 `/etc/systemd/network/99-wg0.netdev`
 ```
 [NetDev]
@@ -51,11 +60,10 @@ ListenPort=51111
 PrivateKey=HOST_KEY
 
 [WireGuardPeer]
-PublicKey=HOST_PUB
+PublicKey=CLIENT_PUB
 AllowedIPs=10.10.10.0/24
 PersistentKeepalive=25
 ```
-(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
 
 `/etc/systemd/network/99-wg0.network`
 ```
@@ -66,7 +74,8 @@ Name=wg0
 Address=10.10.10.1/24
 ```
 
-On the client, create the Wireguard Network Device and Network:
+On the client:
+
 `/etc/systemd/network/99-wg0.netdev`
 ```
 [NetDev]
@@ -79,13 +88,11 @@ ListenPort=51871
 PrivateKey=CLIENT_KEY
 
 [WireGuardPeer]
-PublicKey=CLIENT_PUB
+PublicKey=HOST_PUB
 AllowedIPs=10.10.10.0/24
 Endpoint=HOST_ADDRESS:51111
 PersistentKeepalive=25
 ```
-(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
-
 Replace HOST_ADDRESS with an IP address at which the host can be reached prior to to wireguard interface becoming available.
 
 `/etc/systemd/network/99-wg0.network`
@@ -96,25 +103,30 @@ Name=wg0
 [Network]
 Address=10.10.10.2/24
 ```
-_On both systems_, restrict the permissions of the network device file as it contains sensitive keys, then restart systemd-networkd.
+
+_On both systems_, restrict the permissions of the network device file as it contains a sensitive private key, then restart systemd-networkd.
 ```
 chown root:systemd-network /etc/systemd/network/99-*.netdev
 chmod 0640 /etc/systemd/network/99-*.netdev
 systemctl restart systemd-networkd
 ```
-The hosts should now be able to ping each other using their wireguard-protectd 10.10.10.0/24 addresses.  Additionally, statistics about the connection can be obtaned from the `wg` command:
+The nodes should now be able to ping each other using their wireguard-protected 10.10.10.0/24 addresses.  Additionally, statistics about the connection can be obtaned from the `wg` command:
 ```
 wg show
 ```
+
+### Provision the Cluster
+
 Create a Kind configuration file which instructs the API server to listen on the Wireguard interface and a known port:
 `kind-config.yaml`
 ```
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
-  apiServerAddress: "10.10.10.1" # default 127.0.0.1
-  apiServerPort: 6443 # default random, must be different for each cluster
+  apiServerAddress: "10.10.10.1" # default is 127.0.0.1 (local only)
+  apiServerPort: 6443 # default is random. Note this must be unique per cluster.
 ```
+
 Delete the current cluster if necessary:
 ```
 kind delete cluster --name kind
@@ -131,5 +143,10 @@ From the client, confirm that pods can be listed:
 ```
 kubectl get po --all-namespaces --kubeconfig kind-kubeconfig.yaml
 ```
+### Verify Cluster Provisioned
 
+You should be able to retrieve nodes from the cluster, which should include coredns, kube-proxy, etc.
+```
+kubectl get po --all-namespaces
+```
 

--- a/docs/provision_kind.md
+++ b/docs/provision_kind.md
@@ -1,0 +1,135 @@
+# Provisioning a Kind (Kubernetes in Docker) Cluster
+
+[kind](https://github.com/kubernetes-sigs/kind) is a lightweight tool for running local Kubernetes clusters using containers.  It can be used as the underlying infrastructure for Functions, though it is intended for testing and development rather than production deployment.
+
+This guide walks through the process of configuring a kind cluster to run Functions with the following vserions:
+* kind   v0.8.1 - [Install Kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+* Kubectl v1.17.3 - [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) 
+
+## Quickstart
+
+Starting a new cluster with all defaults is as simple as:
+```
+kind create cluster
+```
+List available clusters:
+```
+kind get clusters
+```
+List running containers will now show a kind process:
+```
+docker ps
+```
+
+## Configure Remotely
+
+This section is optional.
+
+Kind is intended to be a locally-running service, and exposing externally is not recommended.  However, a fully configured kubernetes cluster can often quickly outstrip the resources available on even a well-specd development workstation.  Therefore, creating a Kind cluster network appliance of sorts can be helpful.  One possible way to connect to your kind cluster remotely would be to create a [wireguard](https://www.wireguard.com/) interface upon which to expose the API.  Following is an example assuming linux hosts with systemd:
+
+
+First [Install Wireguard](https://www.wireguard.com/install/)
+
+Create keypair for the host and client.
+```
+wg genkey | tee host.key | wg pubkey > host.pub
+wg genkey | tee client.key | wg pubkey > client.pub
+chmod 600 host.key client.key
+```
+Assuming IPv4 addresses, with the wireguard-protected network 10.10.10.0/24, the host being 10.10.10.1 and the client 10.10.10.2
+
+On the host, create a Wireguard Network Device:
+`/etc/systemd/network/99-wg0.netdev`
+```
+[NetDev]
+Name=wg0
+Kind=wireguard
+Description=WireGuard tunnel wg0
+
+[WireGuard]
+ListenPort=51111
+PrivateKey=HOST_KEY
+
+[WireGuardPeer]
+PublicKey=HOST_PUB
+AllowedIPs=10.10.10.0/24
+PersistentKeepalive=25
+```
+(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
+
+`/etc/systemd/network/99-wg0.network`
+```
+[Match]
+Name=wg0
+
+[Network]
+Address=10.10.10.1/24
+```
+
+On the client, create the Wireguard Network Device and Network:
+`/etc/systemd/network/99-wg0.netdev`
+```
+[NetDev]
+Name=wg0
+Kind=wireguard
+Description=WireGuard tunnel wg0
+
+[WireGuard]
+ListenPort=51871
+PrivateKey=CLIENT_KEY
+
+[WireGuardPeer]
+PublicKey=CLIENT_PUB
+AllowedIPs=10.10.10.0/24
+Endpoint=HOST_ADDRESS:51111
+PersistentKeepalive=25
+```
+(Replace HOST_KEY and HOST_PUB with the keypair created earlier.)
+
+Replace HOST_ADDRESS with an IP address at which the host can be reached prior to to wireguard interface becoming available.
+
+`/etc/systemd/network/99-wg0.network`
+```
+[Match]
+Name=wg0
+
+[Network]
+Address=10.10.10.2/24
+```
+_On both systems_, restrict the permissions of the network device file as it contains sensitive keys, then restart systemd-networkd.
+```
+chown root:systemd-network /etc/systemd/network/99-*.netdev
+chmod 0640 /etc/systemd/network/99-*.netdev
+systemctl restart systemd-networkd
+```
+The hosts should now be able to ping each other using their wireguard-protectd 10.10.10.0/24 addresses.  Additionally, statistics about the connection can be obtaned from the `wg` command:
+```
+wg show
+```
+Create a Kind configuration file which instructs the API server to listen on the Wireguard interface and a known port:
+`kind-config.yaml`
+```
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "10.10.10.1" # default 127.0.0.1
+  apiServerPort: 6443 # default random, must be different for each cluster
+```
+Delete the current cluster if necessary:
+```
+kind delete cluster --name kind
+```
+Start a new cluster using the config:
+```
+kind create cluster --config kind-config.yaml
+```
+Export a kubeconfig and move it to the client machine:
+```
+kind export kubeconfig --kubeconfig kind-kubeconfig.yaml
+```
+From the client, confirm that pods can be listed:
+```
+kubectl get po --all-namespaces --kubeconfig kind-kubeconfig.yaml
+```
+
+

--- a/docs/provision_minikube.md
+++ b/docs/provision_minikube.md
@@ -1,0 +1,1 @@
+# Provision a Minikube Cluster

--- a/docs/provision_minikube.md
+++ b/docs/provision_minikube.md
@@ -1,1 +1,0 @@
-# Provision a Minikube Cluster

--- a/docs/tls/cloudflare-secret.yaml
+++ b/docs/tls/cloudflare-secret.yaml
@@ -1,0 +1,12 @@
+# CloudFlare API key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare
+  namespace: cert-manager
+type: Opaque
+data:
+  # Create token in CloudFlare UI, giving it zone read and dns write
+  # permissions.  Create the value for the token using:
+  #   echo -n 'raw-token-here' | base64
+  token: "Q3VfaHNrbVRRN0x0RU9VVlpGNTlqLXc1eWZuR05neFJyZkFCaWJvYw=="

--- a/docs/tls/letsencrypt-issuer.yaml
+++ b/docs/tls/letsencrypt-issuer.yaml
@@ -1,0 +1,22 @@
+apiVersion: cert-manager.io/v1alpha3
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-issuer
+  namespace: cert-manager
+spec:
+  acme:
+    email: ACME_REGISTERED_EMAIL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # For testing use:
+    # server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource that will be used to store the account's private key.
+      name: letsencrypt-account-key
+    solvers:
+    - dns01:
+        cloudflare:
+          email: CLOUDFLARE_REGISTERED_EMAIL
+          apiTokenSecretRef:
+            name: cloudflare
+            key:  token
+


### PR DESCRIPTION
Adds documentation for configuring a Kind cluster, locally and remote (#59).  Imports a reformatted version of docs from `boson-project/faas-config` (#58), and stubs out other sections.