### PR TITLE
chore: improve version subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func init() {
 // Environment Variables, command arguments and flags.
 func Execute() {
 	// Sets version to a string partially populated by compile-time flags.
-	root.Version = verboseVersion()
+	root.Version = version(verbose)
 
 	// Execute the root of the command tree.
 	if err := root.Execute(); err != nil {


### PR DESCRIPTION
Only print the date and git commit hash on version when `--verbose`, and default version to `v0.0.0` if not populated by `make` (i.e. built from source)