### PR TITLE
docs: initial Go template READMEs

### DIFF
--- a/templates/go/events/README.md
+++ b/templates/go/events/README.md
@@ -1,0 +1,22 @@
+# Go Cloud Events Function
+
+Welcome to your new Go Function! The boilerplate function code can be found in [`handle.go`](handle.go). This Function is meant to respond exclusively to [Cloud Events](https://cloudevents.io/), but you can remove the check for this in the function and it will respond just fine to plain vanilla incoming HTTP requests. 
+
+## Development
+
+Develop new features by adding a test to [`handle_test.go`](handle_test.go) for each feature, and confirm it works with `go test`.
+
+Update the running analog of the funciton using the `faas` CLI or client library, and it can be invoked using a manually-created CloudEvent:
+
+```console
+curl -X POST -d '{"hello": "world"}' \
+  -H'Content-type: application/json' \
+  -H'Ce-id: 1' \
+  -H'Ce-source: cloud-event-example' \
+  -H'Ce-type: dev.knative.example' \
+  -H'Ce-specversion: 1.0' \
+  http://myFunction.example.com/
+```
+
+For more, see [the complete documentation]('https://github.com/boson-project/faas/tree/main/docs')
+

--- a/templates/go/http/README.md
+++ b/templates/go/http/README.md
@@ -1,0 +1,20 @@
+# Go HTTP Function
+
+Welcome to your new Go Function! The boilerplate function code can be found in
+[`handle.go`](handle.go). This Function responds to HTTP requests.
+
+## Development
+
+Develop new features by adding a test to [`handle_test.go`](handle_test.go) for
+each feature, and confirm it works with `go test`.
+
+Update the running analog of the funciton using the `faas` CLI or client
+library, and it can be invoked from your browser or from the command line:
+
+```console
+curl http://myfunction.example.com/
+```
+
+For more, see [the complete documentation]('https://github.com/boson-project/faas/tree/main/docs')
+
+

--- a/templates/node/http/README.md
+++ b/templates/node/http/README.md
@@ -1,4 +1,4 @@
-# Node.js Cloud Events Function
+# Node.js HTTP Function
 
 Welcome to your new Node.js function project! The boilerplate function code can be found in [`index.js`](./index.js). This function will respond to incoming HTTP GET and POST requests. This example function is written synchronously, returning a raw value. If your function performs any asynchronous execution, you can safely add the `async` keyword to the function, and return a `Promise`.
 


### PR DESCRIPTION
This PR adds basic READMEs to the Go templates.  It may be necessary to update them with the link to the full documentation site once it is available, bot for now it links to the GitHub repo `docs/README.md`.  (Resolves #71)