### PR TITLE
chore(actions): add binary uploads to main branch CI

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -8,7 +8,7 @@
 # have unique names:  'Main', 'Develop'
 name: Develop
 
-on: 
+on:
   push:
     branches:
       - develop

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@
 # have unique names:  'Main', 'Develop'
 name: Main
 
-on: 
+on:
   push:
     branches:
       - main
@@ -22,6 +22,15 @@ jobs:
       - name: Test
         run:  make test
       - name: Build
-        run:  make build
+        run:  make cross-platform
       - name: Lint
         run: make check
+      - name: Permissions
+        run: chmod a+x faas_*amd*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Binaries
+          path: |
+            faas_darwin_amd64
+            faas_linux_amd64
+            faas_windows_amd64.exe

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,8 +29,13 @@ jobs:
         run: chmod a+x faas_*amd*
       - uses: actions/upload-artifact@v2
         with:
-          name: Binaries
-          path: |
-            faas_darwin_amd64
-            faas_linux_amd64
-            faas_windows_amd64.exe
+          name: OSX Binary
+          path: faas_darwin_amd64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Linux Binary
+          path: faas_linux_amd64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Windows Binary
+          path: faas_windows_amd64.exe


### PR DESCRIPTION
This will enable non-developers who are interested in trying out the latest builds to easily get a copy pre-release.

![image](https://user-images.githubusercontent.com/15952/92179831-8b796700-ee13-11ea-8d82-fca998ea0737.png)

Once the action has completed, you can click the  Artifacts drop down to pull down a zip archive containing binaries for all three platforms. An optimization would be to have each of the binaries uploaded independently, but I didn't see how to do that in the `upload-artifact` action.

This is a PR intended to land on `main`, so we can start pointing potential testers and fiddlers to https://github.com/lance/faas/actions?query=workflow%3AMain where they can download the latest snapshot.