### PR TITLE
fix: build releases from main branch only

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -3,6 +3,8 @@ name: Releases
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 


### PR DESCRIPTION
This PR modifies the release adds a restriction to the release workflow to only fire off the main branch per the[ workflow docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on).