### PR TITLE
chore: use organization-level secrets for image deployment

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -21,8 +21,8 @@ jobs:
         run:  make image
       - name: Push Image
         env:
-          USER: ${{ secrets.QUAY_USERNAME }}
-          PASS: ${{ secrets.QUAY_PASSWORD }}
+          USER: ${{ secrets.QUAY_USER }}
+          PASS: ${{ secrets.QUAY_TOKEN }}
         run: |
           docker login -u "$USER" -p "$PASS" quay.io 
           make push && make latest


### PR DESCRIPTION
Updates the secrets to use those provided at the organization-level rather than in-repo.  Once confirmed as functional (after this PR is merged and all the workflows fire correctly), the repository-level secrets should be removed.  (Fixes #27)