### PR TITLE
chore(actions): add binary uploads to develop branch CI

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -8,7 +8,7 @@
 # have unique names:  'Main', 'Develop'
 name: Develop
 
-on: 
+on:
   push:
     branches:
       - develop
@@ -22,6 +22,20 @@ jobs:
       - name: Test
         run:  make test
       - name: Build
-        run:  make build
+        run:  make cross-platform
       - name: Lint
         run: make check
+      - name: Permissions
+        run: chmod a+x faas_*amd*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: OSX Binary
+          path: faas_darwin_amd64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Linux Binary
+          path: faas_linux_amd64
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Windows Binary
+          path: faas_windows_amd64.exe


### PR DESCRIPTION
This will enable non-developers who are interested in trying out the latest builds to easily get a copy pre-release.

![image](https://user-images.githubusercontent.com/15952/92259383-2cfcc900-eea5-11ea-8c2d-3843b303d9bb.png)
