### PR TITLE
fix: describe works without Eventing

### DIFF
--- a/knative/describer.go
+++ b/knative/describer.go
@@ -2,6 +2,7 @@ package knative
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -73,7 +74,8 @@ func (describer *Describer) Describe(name string) (description faas.Description,
 	}
 
 	triggers, err := eventingClient.Triggers(namespace).List(metav1.ListOptions{})
-	if err != nil {
+	// IsNotFound -- Eventing is probably not installed on the cluster
+	if err != nil && !errors.IsNotFound(err) {
 		return
 	}
 


### PR DESCRIPTION
`faas describe` fails when Knative Eventing is not present (in particular if the trigger CRD is not installed). While user should have Eventing installed the `faas describe` don't have to fail because of its absence.