### PR TITLE
feat: default to no confirmation prompts for CLI commands

### DIFF
--- a/client.go
+++ b/client.go
@@ -369,7 +369,7 @@ func (c *Client) Build(path string) (err error) {
 		return
 	}
 
-	// Derive Image from the path (preceidence is given to extant config)
+	// Derive Image from the path (precedence is given to extant config)
 	if f.Image, err = DerivedImage(path, c.repository); err != nil {
 		return
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/ory/viper"
 	"github.com/spf13/cobra"
 
@@ -12,21 +14,31 @@ import (
 
 func init() {
 	root.AddCommand(deployCmd)
+	deployCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options - $FAAS_CONFIRM")
 	deployCmd.Flags().StringP("namespace", "n", "", "Override namespace into which the Function is deployed (on supported platforms).  Default is to use currently active underlying platform setting - $FAAS_NAMESPACE")
 	deployCmd.Flags().StringP("path", "p", cwd(), "Path to the function project directory - $FAAS_PATH")
-	deployCmd.Flags().BoolP("yes", "y", false, "When in interactive mode (attached to a TTY) skip prompts. - $FAAS_YES")
 }
 
 var deployCmd = &cobra.Command{
 	Use:        "deploy",
 	Short:      "Deploy an existing Function project to a cluster",
 	SuggestFor: []string{"delpoy", "deplyo"},
-	PreRunE:    bindEnv("namespace", "path", "yes"),
+	PreRunE:    bindEnv("namespace", "path", "confirm"),
 	RunE:       runDeploy,
 }
 
 func runDeploy(cmd *cobra.Command, _ []string) (err error) {
-	config := newDeployConfig().Prompt()
+	config := newDeployConfig()
+	function, err := functionWithOverrides(config.Path, config.Namespace, "")
+	if err != nil {
+		return err
+	}
+	if function.Image == "" {
+		return fmt.Errorf("Cannot determine the Function image name. Have you built it yet?")
+	}
+
+	// Confirm or print configuration
+	config.Prompt()
 
 	pusher := docker.NewPusher()
 	pusher.Verbose = config.Verbose
@@ -38,11 +50,6 @@ func runDeploy(cmd *cobra.Command, _ []string) (err error) {
 		faas.WithVerbose(config.Verbose),
 		faas.WithPusher(pusher),
 		faas.WithDeployer(deployer))
-
-	// overrieNamespace into which the function is deployed, if --namespace provided.
-	if err = overrideNamespace(config.Path, config.Namespace); err != nil {
-		return
-	}
 
 	return client.Deploy(config.Path)
 
@@ -66,9 +73,9 @@ type deployConfig struct {
 	// Verbose logging.
 	Verbose bool
 
-	// Yes: agree to values arrived upon from environment plus flags plus defaults,
-	// and skip the interactive prompting (only applicable when attached to a TTY).
-	Yes bool
+	// Confirm: confirm values arrived upon from environment plus flags plus defaults,
+	// with interactive prompting (only applicable when attached to a TTY).
+	Confirm bool
 }
 
 // newDeployConfig creates a buildConfig populated from command flags and
@@ -78,7 +85,7 @@ func newDeployConfig() deployConfig {
 		Namespace: viper.GetString("namespace"),
 		Path:      viper.GetString("path"),
 		Verbose:   viper.GetBool("verbose"), // defined on root
-		Yes:       viper.GetBool("yes"),
+		Confirm:   viper.GetBool("confirm"),
 	}
 }
 
@@ -86,12 +93,12 @@ func newDeployConfig() deployConfig {
 // Skipped if not in an interactive terminal (non-TTY), or if --yes (agree to
 // all prompts) was explicitly set.
 func (c deployConfig) Prompt() deployConfig {
-	if !interactiveTerminal() || c.Yes {
+	if !interactiveTerminal() || !c.Confirm {
 		return c
 	}
 	return deployConfig{
-		Namespace: prompt.ForString("Override default namespace (optional)", c.Namespace),
-		Path:      prompt.ForString("Path to project directory", c.Path),
-		Verbose:   prompt.ForBool("Verbose logging", c.Verbose),
+		Namespace: prompt.ForString("Namespace", c.Namespace),
+		Path:      prompt.ForString("Project path", c.Path),
+		Verbose:   c.Verbose,
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,6 +150,19 @@ func overrideNamespace(root, override string) (err error) {
 	return f.WriteConfig()
 }
 
+// functionWithOverrides sets the namespace and image strings for the
+// Function project at root, if provided, and returns the Function
+// configuration values
+func functionWithOverrides(root, namespace, image string) (f faas.Function, err error) {
+	if err = overrideNamespace(root, namespace); err != nil {
+		return
+	}
+	if err = overrideImage(root, image); err != nil {
+		return
+	}
+	return faas.NewFunction(root)
+}
+
 // deriveName returns the explicit value (if provided) or attempts to derive
 // from the given path.  Path is defaulted to current working directory, where
 // a function configuration, if it exists and contains a name, is used.  Lastly


### PR DESCRIPTION
The CLI commands all printed confirmation prompts for the various flags
they exposed. This commit modifies that logic, so that there is no longer
a `-y` flag, but instead a `--confirm` or `-c` flag for each command, and
prompts are only displayed if using this flag. In most cases, the derived
values are printed even if not prompted for.

In all cases where the user is prompted, I have removed the "Verbose"
prompt, as that seems less like a configuration option that needs to be
confirmed, and more like just a CLI option for the current run which we
can just accept as-is.

The text for the prompts has also been reduced to one or two words.

Also added are some checks around image naming and repositories, short
circuiting failures that could occur if these are not specified or are
unknown. For example, if a user does `faas init` and then `faas deploy`
we don't yet know what the image name should be - one hasn't been built.

Fixes: https://github.com/boson-project/faas/issues/91
Fixes: https://github.com/boson-project/faas/issues/90
Fixes: https://github.com/boson-project/faas/issues/89