### PR TITLE
src(commands): remove --path flag from most commands

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,7 +33,9 @@ func runBuild(cmd *cobra.Command, _ []string) (err error) {
 	if err != nil {
 		return
 	}
-	function.OverrideImage(config.Image)
+	if err = function.OverrideImage(config.Image); err != nil {
+		return
+	}
 
 	// Ensure that the configuration is actually pointing to a Function project directory.
 	if !function.Initialized() {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -32,7 +32,9 @@ func runDeploy(cmd *cobra.Command, _ []string) (err error) {
 	if err != nil {
 		return
 	}
-	function.OverrideNamespace(config.Namespace)
+	if err = function.OverrideNamespace(config.Namespace); err != nil {
+		return
+	}
 
 	if function.Image == "" {
 		return fmt.Errorf("Cannot determine the Function image name. Have you built it yet?")

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -43,7 +43,9 @@ func runDescribe(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return
 	}
-	function.OverrideNamespace(config.Namespace)
+	if err = function.OverrideNamespace(config.Namespace); err != nil {
+		return
+	}
 
 	describer, err := knative.NewDescriber(config.Namespace)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,45 +119,15 @@ func bindEnv(flags ...string) bindFunc {
 	}
 }
 
-// overrideImage overwrites (or sets) the value of the Function's .Image
-// property, which preempts the default functionality of deriving the value as:
-// Deafult:  [config.Repository]/[config.Name]:latest
-func overrideImage(root, override string) (err error) {
-	if override == "" {
-		return
-	}
-	f, err := faas.NewFunction(root)
-	if err != nil {
-		return err
-	}
-	f.Image = override
-	return f.WriteConfig()
-}
-
-// overrideNamespace overwrites (or sets) the value of the Function's .Namespace
-// property, which preempts the default functionality of using the underlying
-// platform configuration (if supported).  In the case of Kubernetes, this
-// overrides the configured namespace (usually) set in ~/.kube.config.
-func overrideNamespace(root, override string) (err error) {
-	if override == "" {
-		return
-	}
-	f, err := faas.NewFunction(root)
-	if err != nil {
-		return err
-	}
-	f.Namespace = override
-	return f.WriteConfig()
-}
-
 // functionWithOverrides sets the namespace and image strings for the
 // Function project at root, if provided, and returns the Function
 // configuration values
 func functionWithOverrides(root, namespace, image string) (f faas.Function, err error) {
-	if err = overrideNamespace(root, namespace); err != nil {
+
+	if err = f.OverrideNamespace(namespace); err != nil {
 		return
 	}
-	if err = overrideImage(root, image); err != nil {
+	if err = f.OverrideImage(image); err != nil {
 		return
 	}
 	return faas.NewFunction(root)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,20 +119,6 @@ func bindEnv(flags ...string) bindFunc {
 	}
 }
 
-// functionWithOverrides sets the namespace and image strings for the
-// Function project at root, if provided, and returns the Function
-// configuration values
-func functionWithOverrides(root, namespace, image string) (f faas.Function, err error) {
-
-	if err = f.OverrideNamespace(namespace); err != nil {
-		return
-	}
-	if err = f.OverrideImage(image); err != nil {
-		return
-	}
-	return faas.NewFunction(root)
-}
-
 // deriveName returns the explicit value (if provided) or attempts to derive
 // from the given path.  Path is defaulted to current working directory, where
 // a function configuration, if it exists and contains a name, is used.  Lastly

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,9 +22,13 @@ var runCmd = &cobra.Command{
 
 func runRun(cmd *cobra.Command, args []string) (err error) {
 	var (
-		path    = "" // defaults to current working directory
+		path    = cwd()
 		verbose = viper.GetBool("verbose")
 	)
+
+	if _, err = faas.LoadFunction(path); err != nil {
+		return
+	}
 
 	if len(args) == 1 {
 		path = args[0]

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,7 +35,9 @@ func runUpdate(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return
 	}
-	function.OverrideNamespace(config.Namespace)
+	if err = function.OverrideNamespace(config.Namespace); err != nil {
+		return
+	}
 
 	if function.Image == "" {
 		return fmt.Errorf("Cannot determine the Function image. Have you built it yet?")

--- a/function.go
+++ b/function.go
@@ -68,6 +68,43 @@ func NewFunction(root string) (f Function, err error) {
 	return
 }
 
+// LoadFunction loads an existing Function project from disk at 'path'
+// If no Function project exists at the path location, an error is returned.
+func LoadFunction(root string) (f Function, err error) {
+	f, err = NewFunction(root)
+	if err != nil {
+		return
+	}
+	// Ensure that the configuration is actually pointing to a Function project directory.
+	if !f.Initialized() {
+		err = fmt.Errorf("No Function project found at %v", root)
+	}
+	return
+}
+
+// OverrideImage overwrites (or sets) the value of the Function's .Image
+// property, which preempts the default functionality of deriving the value as:
+// Deafult:  [config.Repository]/[config.Name]:latest
+func (f Function) OverrideImage(image string) error {
+	if image == "" {
+		return nil
+	}
+	f.Image = image
+	return f.WriteConfig()
+}
+
+// OverrideNamespace overwrites (or sets) the value of the Function's .Namespace
+// property, which preempts the default functionality of using the underlying
+// platform configuration (if supported).  In the case of Kubernetes, this
+// overrides the configured namespace (usually) set in ~/.kube.config.
+func (f Function) OverrideNamespace(namespace string) error {
+	if namespace == "" {
+		return nil
+	}
+	f.Namespace = namespace
+	return f.WriteConfig()
+}
+
 // WriteConfig writes this Function's configuration to disk.
 func (f Function) WriteConfig() (err error) {
 	return writeConfig(f)


### PR DESCRIPTION
This commit removes the `--path -p` flag for the build, delete, deploy,
describe, run and update commands. The init and create commands have been
left alone for now, pending the outcome of https://github.com/boson-project/faas/issues/123.
The list command doesn't need to know a path, because it's about seeing
all deployed Functions.

Adds a `faas.LoadFunction(path string)` function to load an existing Function
project from disk and return an error if one does not already exist.

Note: I realize this might be controversial. Speak up if you disagree with this proposal!

Edit: The idea here is to enforce the notion that all commands (other than `init` and `create`) are run from within a Function project directory where the configuration file `.faas.yaml` defines the context. Some of the comments from @matejvasek identified areas where functionality has been reduced - e.g. you can't describe or delete a function by name. I think we should actually consider removing these, and possibly even consider removing `faas deploy` and `faas update`. 

BREAKING CHANGE