### PR TITLE
chore: remove [options] from usage string

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 var buildCmd = &cobra.Command{
-	Use:        "build [options]",
+	Use:        "build",
 	Short:      "Build an existing Function project as an OCI image",
 	SuggestFor: []string{"biuld", "buidl", "built"},
 	PreRunE:    bindEnv("image", "path", "repository", "confirm"),

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 var createCmd = &cobra.Command{
-	Use:        "create <name> [options]",
+	Use:        "create <name>",
 	Short:      "Create a new Function, including initialization of local files and deployment.",
 	SuggestFor: []string{"cerate", "new"},
 	PreRunE:    bindEnv("image", "namespace", "path", "repository", "runtime", "templates", "trigger", "confirm"),

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 var describeCmd = &cobra.Command{
-	Use:               "describe <name> [options]",
+	Use:               "describe <name>",
 	Short:             "Describe Function",
 	Long:              `Describes the Function initialized in the current directory, or by passed name argument.`,
 	SuggestFor:        []string{"desc", "get"},

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 var initCmd = &cobra.Command{
-	Use:        "init <name> [options]",
+	Use:        "init <name>",
 	Short:      "Initialize a new Function project",
 	SuggestFor: []string{"inti", "new"},
 	PreRunE:    bindEnv("path", "runtime", "templates", "trigger", "confirm"),

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 var listCmd = &cobra.Command{
-	Use:        "list [options]",
+	Use:        "list",
 	Short:      "Lists deployed Functions",
 	Long:       `Lists deployed Functions`,
 	SuggestFor: []string{"ls", "lsit"},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var updateCmd = &cobra.Command{
-	Use:        "update [options]",
+	Use:        "update",
 	Short:      "Update or create a deployed Function",
 	Long:       `Update deployed Function to match the current local state.`,
 	SuggestFor: []string{"push", "deploy"},


### PR DESCRIPTION
The cobra package, magically appends "[flags]" to the usage string if a command has flags. By adding "[options]" to the usage string, we end up with help text that looks like this.

```
  faas init <name> [options] [flags]
```

This commit fixes that.