### PR TITLE
fix: correct value for config path and robustify

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -23,7 +23,7 @@ func init() {
 	createCmd.Flags().StringP("path", "p", cwd(), "Path to the new project directory - $FAAS_PATH")
 	createCmd.Flags().StringP("repository", "r", "", "Repository for built images, ex 'docker.io/myuser' or just 'myuser'.  Optional if --image provided. - $FAAS_REPOSITORY")
 	createCmd.Flags().StringP("runtime", "l", faas.DefaultRuntime, "Function runtime language/framework. - $FAAS_RUNTIME")
-	createCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "faas", "templates"), "Extensible templates path. - $FAAS_TEMPLATES")
+	createCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "templates"), "Extensible templates path. - $FAAS_TEMPLATES")
 	createCmd.Flags().StringP("trigger", "t", faas.DefaultTrigger, "Function trigger (ex: 'http','events') - $FAAS_TRIGGER")
 
 	var err error

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,7 +16,7 @@ func init() {
 	initCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options - $FAAS_CONFIRM")
 	initCmd.Flags().StringP("path", "p", cwd(), "Path to the new project directory - $FAAS_PATH")
 	initCmd.Flags().StringP("runtime", "l", faas.DefaultRuntime, "Function runtime language/framework. - $FAAS_RUNTIME")
-	initCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "faas", "templates"), "Extensible templates path. - $FAAS_TEMPLATES")
+	initCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "templates"), "Extensible templates path. - $FAAS_TEMPLATES")
 	initCmd.Flags().StringP("trigger", "t", faas.DefaultTrigger, "Function trigger (ex: 'http','events') - $FAAS_TRIGGER")
 
 	if err := initCmd.RegisterFlagCompletionFunc("runtime", CompleteRuntimeList); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,8 +12,6 @@ import (
 	"github.com/boson-project/faas"
 )
 
-var config = configPath() // Location of the optional system-wide config file.
-
 // The root of the command tree defines the command name, descriotion, globally
 // available flags, etc.  It has no action of its own, such that running the
 // resultant binary with no arguments prints the help/usage text.
@@ -31,9 +29,6 @@ Create and run Functions as a Service.`,
 // are invoked to gather system context.  This includes reading the configuration
 // file, environment variables, and parsing the command flags.
 func init() {
-	// Populate `config` var with the value of --config flag, if provided.
-	root.PersistentFlags().StringVar(&config, "config", config, "config file path")
-
 	// read in environment variables that match
 	viper.AutomaticEnv()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/ory/viper"
@@ -11,7 +12,7 @@ import (
 	"github.com/boson-project/faas"
 )
 
-var config = "~/.faas/config" // Location of the optional system-wide config file.
+var config = configPath() // Location of the optional system-wide config file.
 
 // The root of the command tree defines the command name, descriotion, globally
 // available flags, etc.  It has no action of its own, such that running the
@@ -95,11 +96,15 @@ func cwd() (cwd string) {
 // function defaults and extensible templates.
 func configPath() (path string) {
 	if path = os.Getenv("XDG_CONFIG_HOME"); path != "" {
+		path = filepath.Join(path, "faas")
 		return
 	}
-	path, err := homedir.Expand("~/.config")
+	home, err := homedir.Expand("~")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not derive home directory for use as default templates path: %v", err)
+		path = filepath.Join(".config", "faas")
+	} else {
+		path = filepath.Join(home, ".config", "faas")
 	}
 	return
 }


### PR DESCRIPTION
The hardcoded, initial value for the configuration path was set to `.faas/config`. But `configPath()` immediately sets this to the correct value of ~/.config. Both the create and init commands use `configPath()` to search for additional templates, if they exist, and were each doing `filepath.Join(configPath(), "faas", "templates")`. This commit also changes `configPath()` so that it is `~/.config/faas` and does so in a cross platform friendly way. If the `$HOME` directory cannot be determined, the config is assumed to be at `./.config/faas`.