### PR TITLE
src: use go 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/boson-project/faas
 
-go 1.13
+go 1.14
 
 require (
 	github.com/buildpacks/pack v0.13.1


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Is there a specific reason for us to stay on `go 1.13`? `go 1.15` is already out. So updating to `1.14` for now.