### PR TITLE
chore(actions): update release-please-action to latest 2.4.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           make push && make latest
 
       # Create a release, or update the release PR
-      - uses: GoogleCloudPlatform/release-please-action@v2.1.1
+      - uses: GoogleCloudPlatform/release-please-action@v2.4.1
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There was a bug that surfaced in 2.2.0, which we discovered in the faas-js-runtime repo. I thought it would be good to update it everywhere.

Signed-off-by: Lance Ball <lball@redhat.com>