### PR TITLE
feat(kn): Enable faas to be integrated as plugin to kn

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,10 +26,15 @@ var root = &cobra.Command{
 Create and run Functions as a Service.`,
 }
 
+// NewRootCmd is used to initialize faas as kn plugin
+func NewRootCmd() *cobra.Command {
+	return root
+}
+
 // When the code is loaded into memory upon invocation, the cobra/viper packages
 // are invoked to gather system context.  This includes reading the configuration
 // file, environment variables, and parsing the command flags.
-func init() {
+func Init() {
 	// read in environment variables that match
 	viper.AutomaticEnv()
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,42 @@
+package plugin
+
+import (
+	"github.com/boson-project/faas/cmd"
+	"knative.dev/client/pkg/kn/plugin"
+	"os"
+)
+
+func init() {
+	plugin.InternalPlugins = append(plugin.InternalPlugins, &faasPlugin{})
+}
+
+type faasPlugin struct {}
+
+func (f *faasPlugin) Name() string {
+	return "kn-faas"
+}
+
+func (f *faasPlugin) Execute(args []string) error {
+    rootCmd := cmd.NewRootCmd()
+    cmd.Init()
+	oldArgs := os.Args
+	defer (func() {
+		os.Args = oldArgs
+	})()
+	os.Args = append([]string { "kn-faas" }, args...)
+	return rootCmd.Execute()
+}
+
+// Description for faas subcommand visible in 'kn --help'
+func (f *faasPlugin) Description() (string, error) {
+	return "Function as a Service plugin", nil
+}
+
+func (f *faasPlugin) CommandParts() []string {
+	return []string{ "faas"}
+}
+
+// Path is empty because its an internal plugins
+func (f *faasPlugin) Path() string {
+	return ""
+}


### PR DESCRIPTION
Changes:
- Add plugin package to enable faas to be consumed as plugin
- Fix cyclic dependency issue on pkg/kn/root package 
- Optional: changed output to display standard output of `service create` command
  - I'll understand if it isn't desired or needs further discussion :)


Example:
```
➜  test-project kn faas deploy             
Creating service 'test--project' in namespace 'default':

  0.036s The Configuration is still working to reflect the latest desired specification.
  0.059s The Route is still working to reflect the latest desired specification.
  0.109s Configuration "test--project" is waiting for a Revision to become ready.
 10.192s ...
 10.221s Ingress has not yet been reconciled.
 10.273s Waiting for load balancer to be ready
 10.884s Ready to serve.

Service 'test--project' created to latest revision 'test--project-dfwml-1' is available at URL:
http://test--project.default.example.com

```