### PR TITLE
src!: change all references of "repository" to "registry" for images

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,7 +28,7 @@ type Client struct {
 	describer         Describer
 	dnsProvider       DNSProvider      // Provider of DNS services
 	templates         string           // path to extensible templates
-	repository        string           // default repo for OCI image tags
+	registry          string           // default registry for OCI image tags
 	domainSearchLimit int              // max recursion when deriving domain
 	progressListener  ProgressListener // progress listener
 }
@@ -225,13 +225,13 @@ func WithTemplates(templates string) Option {
 	}
 }
 
-// WithRepository sets the default registry which is consulted when an image name/tag
+// WithRegistry sets the default registry which is consulted when an image name/tag
 // is not explocitly provided.  Can be fully qualified, including the registry
 // (ex: 'quay.io/myname') or simply the namespace 'myname' which indicates the
 // the use of the default registry.
-func WithRepository(repository string) Option {
+func WithRegistry(registry string) Option {
 	return func(c *Client) {
-		c.repository = repository
+		c.registry = registry
 	}
 }
 
@@ -377,7 +377,7 @@ func (c *Client) Build(path string) (err error) {
 	}
 
 	// Derive Image from the path (precedence is given to extant config)
-	if f.Image, err = DerivedImage(path, c.repository); err != nil {
+	if f.Image, err = DerivedImage(path, c.registry); err != nil {
 		return
 	}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,9 +15,9 @@ func init() {
 	root.AddCommand(buildCmd)
 	buildCmd.Flags().StringP("builder", "b", "default", "Buildpacks builder")
 	buildCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options - $FAAS_CONFIRM")
-	buildCmd.Flags().StringP("image", "i", "", "Optional full image name, in form [registry]/[namespace]/[name]:[tag] for example quay.io/myrepo/project.name:latest (overrides --repository) - $FAAS_IMAGE")
+	buildCmd.Flags().StringP("image", "i", "", "Optional full image name, in form [registry]/[namespace]/[name]:[tag] for example quay.io/myrepo/project.name:latest (overrides --registry) - $FAAS_IMAGE")
 	buildCmd.Flags().StringP("path", "p", cwd(), "Path to the Function project directory - $FAAS_PATH")
-	buildCmd.Flags().StringP("repository", "r", "", "Repository for built images, ex 'docker.io/myuser' or just 'myuser'.  Optional if --image provided. - $FAAS_REPOSITORY")
+	buildCmd.Flags().StringP("registry", "r", "", "Registry for built images, ex 'docker.io/myuser' or just 'myuser'.  Optional if --image provided. - $FAAS_REGISTRY")
 
 	err := buildCmd.RegisterFlagCompletionFunc("builder", CompleteBuilderList)
 	if err != nil {
@@ -32,12 +32,12 @@ var buildCmd = &cobra.Command{
 
 Builds the Function project in the current directory or in the directory
 specified by the --path flag. The faas.yaml file is read to determine the
-image name and repository. If both of these values are unset in the
-configuration file the --repository or -r flag should be provided and an image
+image name and registry. If both of these values are unset in the
+configuration file the --registry or -r flag should be provided and an image
 name will be derived from the project name.
 
-Any value provided for --image or --repository will be persisted in the
-faas.yaml configuration file. On subsequent invocations of the "build" command
+Any value provided for the --image flag will be persisted in the faas.yaml
+configuration file. On subsequent invocations of the "build" command
 these values will be read from the configuration file.
 
 It's possible to use a custom Buildpack builder with the --builder flag.
@@ -45,7 +45,7 @@ The value may be image name e.g. "cnbs/sample-builder:bionic",
 or reference to builderMaps in the config file e.g. "default".
 `,
 	SuggestFor: []string{"biuld", "buidl", "built"},
-	PreRunE:    bindEnv("image", "path", "builder", "repository", "confirm"),
+	PreRunE:    bindEnv("image", "path", "builder", "registry", "confirm"),
 	RunE:       runBuild,
 }
 
@@ -57,12 +57,12 @@ func runBuild(cmd *cobra.Command, _ []string) (err error) {
 	}
 
 	// If the Function does not yet have an image name, and one was not provided
-	// on the command line AND a --repository was not provided, then we need to
-	// prompt for a repository from which we can derive an image name.
-	if function.Image == "" && config.Repository == "" {
-		fmt.Print("A repository for Function images is required. For example, 'docker.io/tigerteam'.\n\n")
-		config.Repository = prompt.ForString("Repository for Function images", "")
-		if config.Repository == "" {
+	// on the command line AND a --registry was not provided, then we need to
+	// prompt for a registry from which we can derive an image name.
+	if function.Image == "" && config.Registry == "" {
+		fmt.Print("A registry for Function images is required. For example, 'docker.io/tigerteam'.\n\n")
+		config.Registry = prompt.ForString("Registry for Function images", "")
+		if config.Registry == "" {
 			return fmt.Errorf("Unable to determine Function image name")
 		}
 	}
@@ -72,7 +72,7 @@ func runBuild(cmd *cobra.Command, _ []string) (err error) {
 
 	client := faas.New(
 		faas.WithVerbose(config.Verbose),
-		faas.WithRepository(config.Repository), // for deriving image name when --image not provided explicitly.
+		faas.WithRegistry(config.Registry), // for deriving image name when --image not provided explicitly.
 		faas.WithBuilder(builder))
 
 	config.Prompt()
@@ -82,21 +82,19 @@ func runBuild(cmd *cobra.Command, _ []string) (err error) {
 
 type buildConfig struct {
 	// Image name in full, including registry, repo and tag (overrides
-	// image name derivation based on Repository and Function Name)
+	// image name derivation based on Registry and Function Name)
 	Image string
 
 	// Path of the Function implementation on local disk. Defaults to current
 	// working directory of the process.
 	Path string
 
-	// Push the resultnat image to the repository after building.
+	// Push the resulting image to the registry after building.
 	Push bool
 
-	// Repository at which interstitial build artifacts should be kept.
-	// Registry is optional and is defaulted to faas.DefaultRegistry.
-	// ex: "quay.io/myrepo" or "myrepo"
+	// Registry at which interstitial build artifacts should be kept.
 	// This setting is ignored if Image is specified, which includes the full
-	Repository string
+	Registry string
 
 	// Verbose logging.
 	Verbose bool
@@ -109,12 +107,12 @@ type buildConfig struct {
 
 func newBuildConfig() buildConfig {
 	return buildConfig{
-		Image:      viper.GetString("image"),
-		Path:       viper.GetString("path"),
-		Repository: viper.GetString("repository"),
-		Verbose:    viper.GetBool("verbose"), // defined on root
-		Confirm:    viper.GetBool("confirm"),
-		Builder:    viper.GetString("builder"),
+		Image:    viper.GetString("image"),
+		Path:     viper.GetString("path"),
+		Registry: viper.GetString("registry"),
+		Verbose:  viper.GetBool("verbose"), // defined on root
+		Confirm:  viper.GetBool("confirm"),
+		Builder:  viper.GetString("builder"),
 	}
 }
 
@@ -122,7 +120,7 @@ func newBuildConfig() buildConfig {
 // Skipped if not in an interactive terminal (non-TTY), or if --confirm false (agree to
 // all prompts) was set (default).
 func (c buildConfig) Prompt() buildConfig {
-	imageName := deriveImage(c.Image, c.Repository, c.Path)
+	imageName := deriveImage(c.Image, c.Registry, c.Path)
 	if !interactiveTerminal() || !c.Confirm {
 		// If --confirm false or non-interactive, just print the image name
 		fmt.Printf("Building image: %v\n", imageName)
@@ -132,7 +130,7 @@ func (c buildConfig) Prompt() buildConfig {
 		Path:    prompt.ForString("Path to project directory", c.Path),
 		Image:   prompt.ForString("Image name", imageName, prompt.WithRequired(true)),
 		Verbose: c.Verbose,
-		// Repository not prompted for as it would be confusing when combined with explicit image.  Instead it is
-		// inferred by the derived default for Image, which uses Repository for derivation.
+		// Registry not prompted for as it would be confusing when combined with explicit image.  Instead it is
+		// inferred by the derived default for Image, which uses Registry for derivation.
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -195,7 +195,7 @@ func deriveNameAndAbsolutePathFromPath(path string) (string, string) {
 }
 
 // deriveImage returns the same image name which will be used if no explicit
-// image is provided.  I.e. derived from the configured repository (registry
+// image is provided.  I.e. derived from the configured registry (registry
 // plus username) and the Function's name.
 //
 // This is calculated preemptively here in the CLI (prior to invoking the
@@ -214,9 +214,9 @@ func deriveNameAndAbsolutePathFromPath(path string) (string, string) {
 // If the image flag is provided, this value is used directly (the user supplied
 // --image or $FAAS_IMAGE).  Otherwise, the Function at 'path' is loaded, and
 // the Image name therein is used (i.e. it was previously calculated).
-// Finally, the default repository is used, which is prepended to the Function
+// Finally, the default registry is used, which is prepended to the Function
 // name, and appended with ':latest':
-func deriveImage(explicitImage, defaultRepo, path string) string {
+func deriveImage(explicitImage, defaultRegistry, path string) string {
 	if explicitImage != "" {
 		return explicitImage // use the explicit value provided.
 	}
@@ -227,6 +227,6 @@ func deriveImage(explicitImage, defaultRepo, path string) string {
 	if f.Image != "" {
 		return f.Image // use value previously provided or derived.
 	}
-	derivedValue, _ := faas.DerivedImage(path, defaultRepo)
+	derivedValue, _ := faas.DerivedImage(path, defaultRegistry)
 	return derivedValue // Use the faas system's derivation logic.
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,20 +18,20 @@ kn faas init <path> [-l <runtime> -t <trigger>]
 
 ## `build`
 
-Builds the Function project in the current directory. Reads the `faas.yaml` file to determine image name and repository. If both of these values are unset in the configuration file, the user is prompted to provide a repository, from there an image name can be derived. The image name and repository may also be specified as flags, as can the path to the project.
+Builds the Function project in the current directory. Reads the `faas.yaml` file to determine image name and registry. If both of these values are unset in the configuration file, the user is prompted to provide a registry, from there an image name can be derived. The image name and registry may also be specified as flags, as can the path to the project.
 
-The value(s) provided for image and repository are persisted to the `faas.yaml` file so that subsequent invocations do not require the user to specify these again.
+The value(s) provided for image and registry are persisted to the `faas.yaml` file so that subsequent invocations do not require the user to specify these again.
 
 Similar `kn` command: none.
 
 ```console
-faas build [-i <image> -r <repository> -p <path>]
+faas build [-i <image> -r <registry> -p <path>]
 ```
 
 When run as a `kn` plugin.
 
 ```console
-kn faas build [-i <image> -r <repository> -p <path>]
+kn faas build [-i <image> -r <registry> -p <path>]
 ```
 
 ## `run`
@@ -52,25 +52,25 @@ kn faas run
 
 ## `deploy`
 
-Builds and deploys the Function project in the current directory. The user may specify a path to the project directory using the `--path` or `-p` flag. Reads the `faas.yaml` configuration file to determine the image name. An image and repository may be specified on the command line using the  `--image` or `-i` and `--repository` or `-r` flag.
+Builds and deploys the Function project in the current directory. The user may specify a path to the project directory using the `--path` or `-p` flag. Reads the `faas.yaml` configuration file to determine the image name. An image and registry may be specified on the command line using the  `--image` or `-i` and `--registry` or `-r` flag.
 
 Derives the service name from the project name. There is no mechanism by which the user can specify the service name. The user must have already initialized the  function using `faas init` or they will encounter an error.
 
 If the Function is already deployed, it is updated with a new container image that is pushed to a
-container image repository, and the Knative Service is updated.
+container image registry, and the Knative Service is updated.
 
 The namespace into which the project is deployed defaults to the value in the `faas.yaml` configuration file. If `NAMESPACE` is not set in the configuration, the namespace currently active in the Kubernetes configuration file will be used. The namespace may be specified on the command line using the `--namespace` or `-n` flag, and if so this will overwrite the value in the `faas.yaml` file.
 
 Similar `kn` command: `kn service create NAME --image IMAGE [flags]`. This command allows a user to deploy a Knative Service by specifying an image, typically one hosted on a public container registry such as docker.io. The deployment options which the `kn` command affords the user are quite broad. The `kn` command in this case is quite effective for a power user. The `faas deploy` command has a similar end result, but is definitely easier for a user just getting started to be successful with.
 
 ```console
-faas deploy [-n <namespace> -p <path> -i <image> -r <repository>]
+faas deploy [-n <namespace> -p <path> -i <image> -r <registry>]
 ```
 
 When run as a `kn` plugin.
 
 ```console
-kn faas deploy [-n <namespace> -p <path> -i <image> -r <repository>]
+kn faas deploy [-n <namespace> -p <path> -i <image> -r <registry>]
 ```
 
 ## `describe`
@@ -109,18 +109,18 @@ kn faas list [-n <namespace> -p <path>]
 
 Creates a new Function project at _`path`_. If _`path`_ does not exist, it is created. The function name is the name of the leaf directory at _`path`_. After creating the project, it builds a container image and deploys it. This command wraps `init`, `build` and `deploy` all up into one command.
 
-The user may specify the runtime, trigger, image name, image repository, and namespace as flags on the command line. If the image name and image repository are both unspecified, the user will be prompted for a repository name, and the image name can be inferred from that plus the function name. The function name, namespace, image name and repository name are all persisted in the project configuration file `faas.yaml`.
+The user may specify the runtime, trigger, image name, image registry, and namespace as flags on the command line. If the image name and image registry are both unspecified, the user will be prompted for a registry name, and the image name can be inferred from that plus the function name. The function name, namespace and image name are all persisted in the project configuration file `faas.yaml`.
 
 Similar `kn` command: none.
 
 ```console
-faas create <path> -r <repository> -l <runtime> -t <trigger> -i <image> -n <namespace>
+faas create <path> -r <registry> -l <runtime> -t <trigger> -i <image> -n <namespace>
 ```
 
 When run as a `kn` plugin.
 
 ```console
-kn faas create <path> -r <repository> -l <runtime> -t <trigger> -i <image> -n <namespace>
+kn faas create <path> -r <registry> -l <runtime> -t <trigger> -i <image> -n <namespace>
 ```
 
 ## `delete`

--- a/docs/integrators_guide.md
+++ b/docs/integrators_guide.md
@@ -4,7 +4,7 @@ Developer's can integrate directly with the Function system using the client lib
 
 ## Using the Client Library
 
-To create a Client which uses the included buildpacks-based function builder, pushes to a Quay.io repository function container artifacts and deploys to a Knative enabled cluster: 
+To create a Client which uses the included buildpacks-based function builder, pushes to a Quay.io registry function container artifacts and deploys to a Knative enabled cluster: 
 ```go
 package main
 

--- a/templates.go
+++ b/templates.go
@@ -61,7 +61,7 @@ func (n templateWriter) Write(runtime, template string, dest string) error {
 	if n.templates != "" {
 		return copyFilesystem(n.templates, runtime, template, dest)
 	}
-	return fmt.Errorf("A template for runtime '%v' template '%v' was not found internally and no extended repository path was defined.", runtime, template)
+	return fmt.Errorf("A template for runtime '%v' template '%v' was not found internally and no custom template path was defined.", runtime, template)
 }
 
 func copyEmbedded(runtime, template, dest string) error {


### PR DESCRIPTION
When dealing with images, instead of referring to an image repository,
let's use the more correct term "registry", even though we're actually
using "registry/namespace" in most cases.

Fixes: https://github.com/boson-project/faas/issues/154

Signed-off-by: Lance Ball <lball@redhat.com>