### PR TITLE
fix: Fix root cmd init

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,7 @@ func NewRootCmd() *cobra.Command {
 // When the code is loaded into memory upon invocation, the cobra/viper packages
 // are invoked to gather system context.  This includes reading the configuration
 // file, environment variables, and parsing the command flags.
-func Init() {
+func init() {
 	// read in environment variables that match
 	viper.AutomaticEnv()
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,7 +18,6 @@ func (f *faasPlugin) Name() string {
 
 func (f *faasPlugin) Execute(args []string) error {
     rootCmd := cmd.NewRootCmd()
-    cmd.Init()
 	oldArgs := os.Args
 	defer (func() {
 		os.Args = oldArgs


### PR DESCRIPTION
As @matejvasek pointed out I shouldn't change `init()` and rather benefit from it's intended build-in behaviour in `plugin.go`, otherwise standalone faas binary is broken.