### PR TITLE
chore(ci): tweak release-please-action to bump minor pre major.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,11 +47,12 @@ jobs:
           make push && make latest
 
       # Create a release, or update the release PR
-      - uses: GoogleCloudPlatform/release-please-action@v2.4.1
+      - uses: GoogleCloudPlatform/release-please-action@v2.5.5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
+          bump-minor-pre-major: true
 
       # The following steps are only executed if this is a release
       - name: Compress Binaries


### PR DESCRIPTION
This commit modifies the CI action so that it should bump minor versions until we explicitly have a 1.0.0 release. I've also bumped the version of release-please-action to the latest 2.5.5.

I'm not certain, but we will  probably need to close the [existing release PR](https://github.com/boson-project/faas/pull/158) after this lands in order to get a new 0.8.0 PR created.

Signed-off-by: Lance Ball <lball@redhat.com>