### PR TITLE
feat: Better output of build/deploy/delete commands

### DIFF
--- a/client.go
+++ b/client.go
@@ -384,7 +384,7 @@ func (c *Client) Initialize(cfg Function) (err error) {
 // not contain a populated Image.
 func (c *Client) Build(path string) (err error) {
 
-	fmt.Println("Building Function image")
+	fmt.Println("Building function image")
 
 	f, err := NewFunction(path)
 	if err != nil {
@@ -427,7 +427,7 @@ func (c *Client) Deploy(path string) (err error) {
 	}
 
 	// Push the image for the named service to the configured registry
-	fmt.Println("Pushing Function image to the registry")
+	fmt.Println("Pushing function image to the registry")
 	imageDigest, err := c.pusher.Push(f)
 	if err != nil {
 		return
@@ -440,7 +440,7 @@ func (c *Client) Deploy(path string) (err error) {
 	}
 
 	// Deploy a new or Update the previously-deployed Function
-	fmt.Println("Deploying Function to the cluster")
+	fmt.Println("Deploying function to the cluster")
 	return c.deployer.Deploy(f)
 }
 

--- a/client.go
+++ b/client.go
@@ -71,11 +71,11 @@ type Lister interface {
 }
 
 type ListItem struct {
-	Name      string `json:"name" yaml:"name"`
-	Runtime   string `json:"runtime" yaml:"runtime"`
-	URL       string `json:"url" yaml:"url"`
-	KService  string `json:"kservice" yaml:"kservice"`
-	Ready     string `json:"ready" yaml:"ready"`
+	Name     string `json:"name" yaml:"name"`
+	Runtime  string `json:"runtime" yaml:"runtime"`
+	URL      string `json:"url" yaml:"url"`
+	KService string `json:"kservice" yaml:"kservice"`
+	Ready    string `json:"ready" yaml:"ready"`
 }
 
 // ProgressListener is notified of task progress.
@@ -383,9 +383,8 @@ func (c *Client) Initialize(cfg Function) (err error) {
 // Build the Function at path.  Errors if the Function is either unloadable or does
 // not contain a populated Image.
 func (c *Client) Build(path string) (err error) {
-	if c.verbose {
-		fmt.Println("Building Function image:")
-	}
+
+	fmt.Println("Building Function image")
 
 	f, err := NewFunction(path)
 	if err != nil {
@@ -409,9 +408,8 @@ func (c *Client) Build(path string) (err error) {
 
 	// TODO: create a statu structure and return it here for optional
 	// use by the cli for user echo (rather than rely on verbose mode here)
-	if c.verbose {
-		fmt.Printf("Function image has been built, image: %v\n", f.Image)
-	}
+	fmt.Printf("Function image has been built, image: %v\n", f.Image)
+
 	return
 }
 
@@ -429,9 +427,7 @@ func (c *Client) Deploy(path string) (err error) {
 	}
 
 	// Push the image for the named service to the configured registry
-	if c.verbose {
-		fmt.Println("\nPushing Function image to the registry:")
-	}
+	fmt.Println("Pushing Function image to the registry")
 	imageDigest, err := c.pusher.Push(f)
 	if err != nil {
 		return
@@ -444,9 +440,7 @@ func (c *Client) Deploy(path string) (err error) {
 	}
 
 	// Deploy a new or Update the previously-deployed Function
-	if c.verbose {
-		fmt.Println("\nDeploying Function to cluster:")
-	}
+	fmt.Println("Deploying Function to the cluster")
 	return c.deployer.Deploy(f)
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -138,8 +138,6 @@ func newBuildConfig() buildConfig {
 func (c buildConfig) Prompt() buildConfig {
 	imageName := deriveImage(c.Image, c.Registry, c.Path)
 	if !interactiveTerminal() || !c.Confirm {
-		// If --confirm false or non-interactive, just print the image name
-		fmt.Printf("Building image: %v\n", imageName)
 		return c
 	}
 	return buildConfig{

--- a/knative/deployer.go
+++ b/knative/deployer.go
@@ -91,6 +91,14 @@ func (d *Deployer) Deploy(f faas.Function) (err error) {
 			err = fmt.Errorf("knative deployer failed to update the service: %v", err)
 			return err
 		}
+
+		route, err := client.GetRoute(serviceName)
+		if err != nil {
+			err = fmt.Errorf("knative deployer failed to get the route: %v", err)
+			return err
+		}
+
+		fmt.Println("Function updated at URL: " + route.Status.URL.String())
 	}
 
 	return nil

--- a/knative/remover.go
+++ b/knative/remover.go
@@ -35,9 +35,8 @@ func (remover *Remover) Remove(name string) (err error) {
 		return
 	}
 
-	if remover.Verbose {
-		fmt.Printf("Removing Knative Service: %v\n", serviceName)
-	}
+	fmt.Printf("Removing Knative Service: %v\n", serviceName)
+	
 	err = client.DeleteService(serviceName, time.Second*60)
 	if err != nil {
 		err = fmt.Errorf("knative remover failed to delete the service: %v", err)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Discussed this with @lkingland, Implementing the spinner properly (so it is not eating the output) may take some time. So I'll proceed with printing some basic info messages, since we are under such a tight deadline.

And we will revisit the Spinner properly for all the commands as a post Dev Preview task.

**Build**
```
./faas build -p func                                        
Building function image
Function image has been built, image: docker.io/zroubalik/func:latest
```

**Deploy**
```
 ./faas deploy -p func                                           
Building function image
Function image has been built, image: docker.io/zroubalik/func:latest
Pushing function image to the registry
Deploying function to the cluster
Function deployed at URL: http://func-default.apps.zroubali.devcluster.openshift.com
```

**Update**
```
./faas deploy -p func                                 
Building function image
Function image has been built, image: docker.io/zroubalik/func:latest
Pushing function image to the registry
Deploying function to the cluster
Function updated at URL: http://func-default.apps.zroubali.devcluster.openshift.com
```

**Delete**
```
./faas delete -p func
Removing Knative Service: func
```

Fixes: #189 