### PR TITLE
chore: Update help messages and adding examples.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,7 +15,7 @@ func init() {
 	root.AddCommand(buildCmd)
 	buildCmd.Flags().StringP("builder", "b", "default", "Buildpack builder, either an as a an image name or a mapping name as defined in func.yaml")
 	buildCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
-	buildCmd.Flags().StringP("image", "i", "", "Full image name in the orm [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over -registry (Env: $FUNC_IMAGE")
+	buildCmd.Flags().StringP("image", "i", "", "Full image name in the orm [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE")
 	buildCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
 	buildCmd.Flags().StringP("registry", "r", "", "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
 
@@ -33,22 +33,22 @@ var buildCmd = &cobra.Command{
 This command builds the function project in the current directory or in the directory
 specified by --path. The result will be a container image that is pushed to a registry.
 The func.yaml file is read to determine the image name and registry. 
-If not already configured, either --registry or --image has to be provided and is then stored 
-in the configuration file.
+If the project has not already been built, either --registry or --image must be provided 
+and the image name is stored in the configuration file.
 `,
     Example: `
 # Build from the local directory, using the given registry as target.
-# The full image name will be automatically will determined automatically based on the
-# project directories name
+# The full image name will be determined automatically based on the
+# project directory name
 kn func build --registry quay.io/myuser
 
-# Build from the local directory with specifying the full image name
+# Build from the local directory, specifying the full image name
 kn func build --image quay.io/myuser/myfunc
 
-# Re-build with picking up previous given arguments from a local func.yml
+# Re-build, picking up a previously supplied image name from a local func.yml
 kn func build
 
-# Build with a custom buildpack
+# Build with a custom buildpack builder
 kn func build --builder cnbs/sample-builder:bionic
 `,
 	SuggestFor: []string{"biuld", "buidl", "built"},
@@ -149,7 +149,7 @@ func (c buildConfig) Prompt() buildConfig {
 	}
 	return buildConfig{
 		Path:    prompt.ForString("Path to project directory", c.Path),
-		Image:   prompt.ForString("Full Image name (e.g. quay.io/boson/node-sample)", imageName, prompt.WithRequired(true)),
+		Image:   prompt.ForString("Full image name (e.g. quay.io/boson/node-sample)", imageName, prompt.WithRequired(true)),
 		Verbose: c.Verbose,
 		// Registry not prompted for as it would be confusing when combined with explicit image.  Instead it is
 		// inferred by the derived default for Image, which uses Registry for derivation.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -13,36 +13,43 @@ import (
 
 func init() {
 	root.AddCommand(buildCmd)
-	buildCmd.Flags().StringP("builder", "b", "default", "Buildpacks builder")
-	buildCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options - $FUNC_CONFIRM")
-	buildCmd.Flags().StringP("image", "i", "", "Optional full image name, in form [registry]/[namespace]/[name]:[tag] for example quay.io/myrepo/project.name:latest (overrides --registry) - $FUNC_IMAGE")
-	buildCmd.Flags().StringP("path", "p", cwd(), "Path to the Function project directory - $FUNC_PATH")
-	buildCmd.Flags().StringP("registry", "r", "", "Registry for built images, ex 'docker.io/myuser' or just 'myuser'.  Optional if --image provided. - $FUNC_REGISTRY")
+	buildCmd.Flags().StringP("builder", "b", "default", "Buildpack builder, either an as a an image name or a mapping name as defined in func.yaml")
+	buildCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
+	buildCmd.Flags().StringP("image", "i", "", "Full image name in the orm [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over -registry (Env: $FUNC_IMAGE")
+	buildCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
+	buildCmd.Flags().StringP("registry", "r", "", "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")
 
 	err := buildCmd.RegisterFlagCompletionFunc("builder", CompleteBuilderList)
 	if err != nil {
-		fmt.Println("Error while calling RegisterFlagCompletionFunc: ", err)
+		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
 }
 
 var buildCmd = &cobra.Command{
 	Use:   "build",
-	Short: "Build an existing Function project as an OCI image",
-	Long: `Build an existing Function project as an OCI image
+	Short: "Build a function project as a container image",
+	Long: `Build a function project as a container image
 
-Builds the Function project in the current directory or in the directory
-specified by the --path flag. The func.yaml file is read to determine the
-image name and registry. If both of these values are unset in the
-configuration file the --registry or -r flag should be provided and an image
-name will be derived from the project name.
+This command builds the function project in the current directory or in the directory
+specified by --path. The result will be a container image that is pushed to a registry.
+The func.yaml file is read to determine the image name and registry. 
+If func.yaml does not exists, either --registry or --image has to be provided and the 
+configuration file be created automatically.
+`,
+    Example: `
+# Build from the local directory, using the given registry as target.
+# The full image name will be automatically will determined automatically based on the
+# project directories name
+kn func build --registry quay.io/boson
 
-Any value provided for the --image flag will be persisted in the func.yaml
-configuration file. On subsequent invocations of the "build" command
-these values will be read from the configuration file.
+# Build from the local directory with specifying the full image name
+kn func build --image quay.io/boson/node-sample
 
-It's possible to use a custom Buildpack builder with the --builder flag.
-The value may be image name e.g. "cnbs/sample-builder:bionic",
-or reference to builderMaps in the config file e.g. "default".
+# Re-build with picking up previous given arguments from a local func.yml
+kn func build
+
+# Build with a custom buildpack
+kn func build --builder cnbs/sample-builder:bionic
 `,
 	SuggestFor: []string{"biuld", "buidl", "built"},
 	PreRunE:    bindEnv("image", "path", "builder", "registry", "confirm"),
@@ -59,7 +66,7 @@ func runBuild(cmd *cobra.Command, _ []string) (err error) {
 
 	// Check if the Function has been initialized
 	if !function.Initialized() {
-		return fmt.Errorf("the given path '%v' does not contain an initialized Function. Please create one at this path before deploying.", config.Path)
+		return fmt.Errorf("the given path '%v' does not contain an initialized function. Please create one at this path before deploying", config.Path)
 	}
 
 	// If the Function does not yet have an image name and one was not provided on the command line
@@ -67,10 +74,10 @@ func runBuild(cmd *cobra.Command, _ []string) (err error) {
 		//  AND a --registry was not provided, then we need to
 		// prompt for a registry from which we can derive an image name.
 		if config.Registry == "" {
-			fmt.Print("A registry for Function images is required. For example, 'docker.io/tigerteam'.\n\n")
-			config.Registry = prompt.ForString("Registry for Function images", "")
+			fmt.Print("A registry for function images is required (e.g. 'quay.io/boson').\n\n")
+			config.Registry = prompt.ForString("Registry for function images", "")
 			if config.Registry == "" {
-				return fmt.Errorf("Unable to determine Function image name")
+				return fmt.Errorf("unable to determine function image name")
 			}
 		}
 
@@ -142,7 +149,7 @@ func (c buildConfig) Prompt() buildConfig {
 	}
 	return buildConfig{
 		Path:    prompt.ForString("Path to project directory", c.Path),
-		Image:   prompt.ForString("Image name", imageName, prompt.WithRequired(true)),
+		Image:   prompt.ForString("Full Image name (e.g. quay.io/boson/node-sample)", imageName, prompt.WithRequired(true)),
 		Verbose: c.Verbose,
 		// Registry not prompted for as it would be confusing when combined with explicit image.  Instead it is
 		// inferred by the derived default for Image, which uses Registry for derivation.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,17 +33,17 @@ var buildCmd = &cobra.Command{
 This command builds the function project in the current directory or in the directory
 specified by --path. The result will be a container image that is pushed to a registry.
 The func.yaml file is read to determine the image name and registry. 
-If func.yaml does not exists, either --registry or --image has to be provided and the 
-configuration file be created automatically.
+If not already configured, either --registry or --image has to be provided and is then stored 
+in the configuration file.
 `,
     Example: `
 # Build from the local directory, using the given registry as target.
 # The full image name will be automatically will determined automatically based on the
 # project directories name
-kn func build --registry quay.io/boson
+kn func build --registry quay.io/myuser
 
 # Build from the local directory with specifying the full image name
-kn func build --image quay.io/boson/node-sample
+kn func build --image quay.io/myuser/myfunc
 
 # Re-build with picking up previous given arguments from a local func.yml
 kn func build

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,7 +14,7 @@ func init() {
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
 	Use:   "completion <bash|zsh|fish>",
-	Short: "Generate bash/zsh completion scripts",
+	Short: "Generate completion scripts for bash and zsh",
 	Long: `To load completion run
 
 For zsh:

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,7 +14,7 @@ func init() {
 // completionCmd represents the completion command
 var completionCmd = &cobra.Command{
 	Use:   "completion <bash|zsh|fish>",
-	Short: "Generate completion scripts for bash and zsh",
+	Short: "Generate completion scripts for bash, fish and zsh",
 	Long: `To load completion run
 
 For zsh:

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,31 +13,36 @@ import (
 
 func init() {
 	root.AddCommand(createCmd)
-	createCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options - $FUNC_CONFIRM")
-	createCmd.Flags().StringP("runtime", "l", faas.DefaultRuntime, "Function runtime language/framework. Default runtime is 'node'. Available runtimes: 'node', 'quarkus' and 'go'. - $FUNC_RUNTIME")
-	createCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "templates"), "Extensible templates path. - $FUNC_TEMPLATES")
-	createCmd.Flags().StringP("trigger", "t", faas.DefaultTrigger, "Function trigger. Default trigger is 'http'. Available triggers: 'http' and 'events' - $FUNC_TRIGGER")
+	createCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNCTION_CONFIRM)")
+	createCmd.Flags().StringP("runtime", "l", faas.DefaultRuntime, "Function runtime language/framework. Available runtimes: 'node', 'quarkus' and 'go' (Env: $FUNCTION_RUNTIME)")
+	createCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "templates"), "Path to additional templates (Env: $FUNCTION_TEMPLATES)")
+	createCmd.Flags().StringP("trigger", "t", faas.DefaultTrigger, "Function trigger. Available triggers: 'http' and 'events' (Env: $FUNCTION_TRIGGER)")
 
 	if err := createCmd.RegisterFlagCompletionFunc("runtime", CompleteRuntimeList); err != nil {
-		fmt.Println("Error while calling RegisterFlagCompletionFunc: ", err)
+		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
 }
 
 var createCmd = &cobra.Command{
-	Use:   "create <path>",
-	Short: "Create a new Function project",
-	Long: `Create a new Function project
+	Use:   "create [PATH]",
+	Short: "Create a function project",
+	Long: `Create a function project
 
-Creates a new Function project at <path>. If <path> does not exist, it is
-created. The Function name is the name of the leaf directory at <path>.
+Creates a new function project in PATH, or in the current directory if no PATH is given. 
+The name of the project is determined by the directory name the project is created in.
+`,
+	Example: `
+# Create a Node.js function project in the current directory, choosing the
+# directory name as the project's name.
+kn func create
 
-A project for a Node.js Function will be created by default. Specify an
-alternate runtime with the --language or -l flag. Available alternates are
-"quarkus" and "go".
+# Create a Quarkus function project in the directory "sample-service". 
+# The directory will be created in the local directory if non-existant and 
+# the project is called "sample-service"
+kn func create --runtime quarkus sample-service
 
-Use the --trigger or -t flag to specify the function invocation context.
-By default, the trigger is "http". To create a Function for CloudEvents, use
-"events".
+# Create a function project that uses a CloudEvent based function signature
+kn func create --trigger events sample-service
 `,
 	SuggestFor: []string{"inti", "new"},
 	PreRunE:    bindEnv("runtime", "templates", "trigger", "confirm"),

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,10 +13,10 @@ import (
 
 func init() {
 	root.AddCommand(createCmd)
-	createCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNCTION_CONFIRM)")
-	createCmd.Flags().StringP("runtime", "l", faas.DefaultRuntime, "Function runtime language/framework. Available runtimes: 'node', 'quarkus' and 'go' (Env: $FUNCTION_RUNTIME)")
-	createCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "templates"), "Path to additional templates (Env: $FUNCTION_TEMPLATES)")
-	createCmd.Flags().StringP("trigger", "t", faas.DefaultTrigger, "Function trigger. Available triggers: 'http' and 'events' (Env: $FUNCTION_TRIGGER)")
+	createCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
+	createCmd.Flags().StringP("runtime", "l", faas.DefaultRuntime, "Function runtime language/framework. Available runtimes: 'node', 'quarkus' and 'go' (Env: $FUNC_RUNTIME)")
+	createCmd.Flags().StringP("templates", "", filepath.Join(configPath(), "templates"), "Path to additional templates (Env: $FUNC_TEMPLATES)")
+	createCmd.Flags().StringP("trigger", "t", faas.DefaultTrigger, "Function trigger. Available triggers: 'http' and 'events' (Env: $FUNC_TRIGGER)")
 
 	if err := createCmd.RegisterFlagCompletionFunc("runtime", CompleteRuntimeList); err != nil {
 		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
@@ -37,12 +37,12 @@ The name of the project is determined by the directory name the project is creat
 kn func create
 
 # Create a Quarkus function project in the directory "sample-service". 
-# The directory will be created in the local directory if non-existant and 
+# The directory will be created in the local directory if non-existent and 
 # the project is called "sample-service"
-kn func create --runtime quarkus sample-service
+kn func create --runtime quarkus myfunc
 
 # Create a function project that uses a CloudEvent based function signature
-kn func create --trigger events sample-service
+kn func create --trigger events myfunc
 `,
 	SuggestFor: []string{"inti", "new"},
 	PreRunE:    bindEnv("runtime", "templates", "trigger", "confirm"),

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -33,7 +33,7 @@ No local files are deleted.
 # Undeploy the function defined in the local directory
 kn func delete
 
-# Undeploy the function 'mynode-func' in namespace 'apps'
+# Undeploy the function 'myfunc' in namespace 'apps'
 kn func delete -n apps myfunc
 `,
 	SuggestFor:        []string{"remove", "rm", "del"},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -20,8 +20,8 @@ func init() {
 
 var deleteCmd = &cobra.Command{
 	Use:   "delete <name>",
-	Short: "Delete a Function deployment",
-	Long: `Delete a Function deployment
+	Short: "Undeploy a function",
+	Long: `Undeploy a function
 
 Removes a deployed function from the cluster. The user may specify a function
 by name, path using the --path or -p flag, or if neither of those are provided,

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -13,25 +13,28 @@ import (
 
 func init() {
 	root.AddCommand(deleteCmd)
-	deleteCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options - $FUNC_CONFIRM")
-	deleteCmd.Flags().StringP("path", "p", cwd(), "Path to the project which should be deleted - $FUNC_PATH")
-	deleteCmd.Flags().StringP("namespace", "n", "", "Override namespace in which to search for Functions.  Default is to use currently active underlying platform setting - $FAAS_NAMESPACE")
+	deleteCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
+	deleteCmd.Flags().StringP("path", "p", cwd(), "Path to the function project that should be undeployed (Env: $FUNC_PATH)")
+	deleteCmd.Flags().StringP("namespace", "n", "", "Namespace of the function to undeploy. By default, the namespace in func.yaml is used or the actual active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)")
 }
 
 var deleteCmd = &cobra.Command{
-	Use:   "delete <name>",
+	Use:   "delete [NAME]",
 	Short: "Undeploy a function",
 	Long: `Undeploy a function
 
-Removes a deployed function from the cluster. The user may specify a function
-by name, path using the --path or -p flag, or if neither of those are provided,
-the current directory will be searched for a func.yaml configuration file to
-determine the function to be removed.
+This command undeploys a function from the cluster. By default the function from 
+the project in the current directory is undeployed. Alternatively either the name 
+of the function can be given as argument or the project path provided with --path.
 
-The namespace defaults to the value in func.yaml or the namespace currently
-active in the user's Kubernetes configuration. The namespace may be specified
-on the command line using the --namespace or -n flag, and if so this will
-overwrite the value in func.yaml.
+No local files are deleted.
+`,
+	Example: `
+# Undeploy the function defined in the local directory
+kn func delete
+
+# Undeploy the function 'mynode-func' in namespace 'apps'
+kn func delete -n apps myfunc
 `,
 	SuggestFor:        []string{"remove", "rm", "del"},
 	ValidArgsFunction: CompleteFunctionList,
@@ -49,7 +52,7 @@ func runDelete(cmd *cobra.Command, args []string) (err error) {
 
 	// Check if the Function has been initialized
 	if !function.Initialized() {
-		return fmt.Errorf("the given path '%v' does not contain an initialized Function.", config.Path)
+		return fmt.Errorf("the given path '%v' does not contain an initialized function", config.Path)
 	}
 
 	remover, err := knative.NewRemover(config.Namespace)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,7 +17,7 @@ func init() {
 	root.AddCommand(deployCmd)
 	deployCmd.Flags().BoolP("confirm", "c", false, "Prompt to confirm all configuration options (Env: $FUNC_CONFIRM)")
 	deployCmd.Flags().StringArrayP("env", "e", []string{}, "Environment variable to set in the form NAME=VALUE. You may provide this flag multiple times for setting multiple environment variables.")
-	deployCmd.Flags().StringP("image", "i", "", "Full image name in the orm [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over -registry (Env: $FUNC_IMAGE")
+	deployCmd.Flags().StringP("image", "i", "", "Full image name in the orm [registry]/[namespace]/[name]:[tag] (optional). This option takes precedence over --registry (Env: $FUNC_IMAGE")
 	deployCmd.Flags().StringP("namespace", "n", "", "Namespace of the function to undeploy. By default, the namespace in func.yaml is used or the actual active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)")
 	deployCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
 	deployCmd.Flags().StringP("registry", "r", "", "Registry + namespace part of the image to build, ex 'quay.io/myuser'.  The full image name is automatically determined based on the local directory name. If not provided the registry will be taken from func.yaml (Env: $FUNC_REGISTRY)")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -25,8 +25,8 @@ func init() {
 
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "Deploy an existing Function project to a cluster",
-	Long: `Deploy an existing Function project to a cluster
+	Short: "Deploy a function",
+	Long: `Deploy a function
 
 Builds and Deploys the Function project in the current directory. 
 A path to the project directory may be provided using the --path or -p flag.

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -65,7 +65,7 @@ func runDeploy(cmd *cobra.Command, _ []string) (err error) {
 
 	// Check if the Function has been initialized
 	if !function.Initialized() {
-		return fmt.Errorf("the given path '%v' does not contain an initialized Function. Please create one at this path before deploying.", config.Path)
+		return fmt.Errorf("the given path '%v' does not contain an initialized function. Please create one at this path before deploying", config.Path)
 	}
 
 	// If the Function does not yet have an image name and one was not provided on the command line
@@ -76,7 +76,7 @@ func runDeploy(cmd *cobra.Command, _ []string) (err error) {
 			fmt.Print("A registry for Function images is required. For example, 'docker.io/tigerteam'.\n\n")
 			config.Registry = prompt.ForString("Registry for Function images", "")
 			if config.Registry == "" {
-				return fmt.Errorf("Unable to determine Function image name")
+				return fmt.Errorf("unable to determine function image name")
 			}
 		}
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -29,8 +29,8 @@ func init() {
 
 var describeCmd = &cobra.Command{
 	Use:   "describe <name>",
-	Short: "Describes the Function",
-	Long: `Describes the Function
+	Short: "Show details of a function",
+	Long: `Show details of a function
 
 Prints the name, route and any event subscriptions for a deployed Function in
 the current directory. A path to a Function project directory may be supplied

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -23,7 +23,7 @@ func init() {
 
 	err := describeCmd.RegisterFlagCompletionFunc("format", CompleteOutputFormatList)
 	if err != nil {
-		fmt.Println("Internal: error while calling RegisterFlagCompletionFunc: ", err)
+		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
 }
 
@@ -58,7 +58,7 @@ func runDescribe(cmd *cobra.Command, args []string) (err error) {
 
 	// Check if the Function has been initialized
 	if !function.Initialized() {
-		return fmt.Errorf("the given path '%v' does not contain an initialized Function.", config.Path)
+		return fmt.Errorf("the given path '%v' does not contain an initialized function", config.Path)
 	}
 
 	describer, err := knative.NewDescriber(config.Namespace)

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -39,7 +39,7 @@ the current directory or from the directory specified with --path.
 # Show the details of a function as declared in the local func.yaml
 kn func describe
 
-# Show the details of the function in YAML format and that is defined in another directory
+# Show the details of the function in YAML format for the function in the myotherfunc directory
 kn func describe --format yaml --path myotherfunc
 `,
 	SuggestFor:        []string{"desc", "get"},

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -17,13 +17,13 @@ import (
 
 func init() {
 	root.AddCommand(describeCmd)
-	describeCmd.Flags().StringP("namespace", "n", "", "Override namespace in which to search for the Function.  Default is to use currently active underlying platform setting - $FUNC_NAMESPACE")
-	describeCmd.Flags().StringP("format", "f", "human", "optionally specify output format (human|plain|json|xml|yaml) $FUNC_FORMAT")
-	describeCmd.Flags().StringP("path", "p", cwd(), "Path to the project which should be described - $FUNC_PATH")
+	describeCmd.Flags().StringP("namespace", "n", "", "Namespace of the function to undeploy. By default, the namespace in func.yaml is used or the actual active namespace if not set in the configuration. (Env: $FUNC_NAMESPACE)")
+	describeCmd.Flags().StringP("format", "f", "human", "Output format (human|plain|json|xml|yaml) (Env: $FUNC_FORMAT)")
+	describeCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
 
 	err := describeCmd.RegisterFlagCompletionFunc("format", CompleteOutputFormatList)
 	if err != nil {
-		fmt.Println("Error while calling RegisterFlagCompletionFunc: ", err)
+		fmt.Println("Internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
 }
 
@@ -32,13 +32,15 @@ var describeCmd = &cobra.Command{
 	Short: "Show details of a function",
 	Long: `Show details of a function
 
-Prints the name, route and any event subscriptions for a deployed Function in
-the current directory. A path to a Function project directory may be supplied
-using the --path or -p flag.
+Prints the name, route and any event subscriptions for a deployed function in
+the current directory or from the directory specified with --path.
+`,
+    Example: `
+# Show the details of a function as declared in the local func.yaml
+kn func describe
 
-The namespace defaults to the value in func.yaml or the namespace currently
-active in the user's Kubernetes configuration. The namespace may be specified
-using the --namespace or -n flag, and if so this will overwrite the value in func.yaml.
+# Show the details of the function in YAML format and that is defined in another directory
+kn func describe --format yaml --path myotherfunc
 `,
 	SuggestFor:        []string{"desc", "get"},
 	ValidArgsFunction: CompleteFunctionList,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,12 +18,11 @@ import (
 
 func init() {
 	root.AddCommand(listCmd)
-	listCmd.Flags().StringP("namespace", "n", "", "Override namespace in which to search for Functions.  Default is to use currently active underlying platform setting - $FUNC_NAMESPACE")
-	listCmd.Flags().StringP("format", "f", "human", "optionally specify output format (human|plain|json|xml|yaml) $FUNC_FORMAT")
-
+	listCmd.Flags().StringP("namespace", "n", "", "Namespace of the function to undeploy. By default, the functions of the actual active namespace are listed. (Env: $FUNC_NAMESPACE)")
+	listCmd.Flags().StringP("format", "f", "human", "Output format (human|plain|json|xml|yaml) (Env: $FUNC_FORMAT)")
 	err := listCmd.RegisterFlagCompletionFunc("format", CompleteOutputFormatList)
 	if err != nil {
-		fmt.Println("Error while calling RegisterFlagCompletionFunc: ", err)
+		fmt.Println("Internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
 }
 
@@ -32,10 +31,11 @@ var listCmd = &cobra.Command{
 	Short: "List functions",
 	Long: `List functions
 
-Lists all deployed functions. The namespace defaults to the value in func.yaml
-or the namespace currently active in the user's Kubernetes configuration. The
-namespace may be specified on the command line using the --namespace or -n flag.
-If specified this will overwrite the value in func.yaml.
+Lists all deployed functions in a given namespace.
+`,
+	Example: `
+# List all functions in the current namespace in human readable format
+kn func list
 `,
 	SuggestFor: []string{"ls", "lsit"},
 	PreRunE:    bindEnv("namespace", "format"),

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,8 +29,8 @@ func init() {
 
 var listCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Lists deployed Functions",
-	Long: `Lists deployed Functions
+	Short: "List functions",
+	Long: `List functions
 
 Lists all deployed functions. The namespace defaults to the value in func.yaml
 or the namespace currently active in the user's Kubernetes configuration. The

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,7 +22,7 @@ func init() {
 	listCmd.Flags().StringP("format", "f", "human", "Output format (human|plain|json|xml|yaml) (Env: $FUNC_FORMAT)")
 	err := listCmd.RegisterFlagCompletionFunc("format", CompleteOutputFormatList)
 	if err != nil {
-		fmt.Println("Internal: error while calling RegisterFlagCompletionFunc: ", err)
+		fmt.Println("internal: error while calling RegisterFlagCompletionFunc: ", err)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,15 +109,15 @@ func cwd() (cwd string) {
 // function defaults and extensible templates.
 func configPath() (path string) {
 	if path = os.Getenv("XDG_CONFIG_HOME"); path != "" {
-		path = filepath.Join(path, "function")
+		path = filepath.Join(path, "func")
 		return
 	}
 	home, err := homedir.Expand("~")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not derive home directory for use as default templates path: %v", err)
-		path = filepath.Join(".config", "function")
+		path = filepath.Join(".config", "func")
 	} else {
-		path = filepath.Join(home, ".config", "function")
+		path = filepath.Join(home, ".config", "func")
 	}
 	return
 }
@@ -229,7 +229,7 @@ func deriveNameAndAbsolutePathFromPath(path string) (string, string) {
 // will be prepended.
 //
 // If the image flag is provided, this value is used directly (the user supplied
-// --image or $FUNCTION_IMAGE).  Otherwise, the Function at 'path' is loaded, and
+// --image or $FUNC_IMAGE).  Otherwise, the Function at 'path' is loaded, and
 // the Image name therein is used (i.e. it was previously calculated).
 // Finally, the default registry is used, which is prepended to the Function
 // name, and appended with ':latest':

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var root = &cobra.Command{
 
 Create, build and deploy functions in serverless containers for multiple runtimes on Knative`,
 	Example: `
-# Create a fresh node function called "node-sample" and enter the directory
+# Create a node function called "node-sample" and enter the directory
 kn func create node-sample
 cd node-sample
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,19 @@ var root = &cobra.Command{
 	SilenceUsage:  true, // no usage dump on error
 	Long: `Serverless functions
 
-Create, build and deploy functions in serverless containers for multiple runtimes on Knative.`,
+Create, build and deploy functions in serverless containers for multiple runtimes on Knative`,
+	Example: `
+# Create a fresh node function called "node-sample" and enter the directory
+kn func create node-sample
+cd node-sample
+
+# Build the container image, push it to a registry and deploy it to the connected Knative cluster
+# (replace <registry/user> with something like quay.io/user with an account that have you access to)
+kn func deploy --registry <registry/user>
+
+# Curl the service with the service URL
+curl $(kn service describe node-sample -o url)
+`,
 }
 
 // NewRootCmd is used to initialize faas as kn plugin

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,15 +26,14 @@ var root = &cobra.Command{
 Create, build and deploy functions in serverless containers for multiple runtimes on Knative`,
 	Example: `
 # Create a node function called "node-sample" and enter the directory
-kn func create node-sample
-cd node-sample
+kn func create myfunc && cd myfunc
 
 # Build the container image, push it to a registry and deploy it to the connected Knative cluster
 # (replace <registry/user> with something like quay.io/user with an account that have you access to)
 kn func deploy --registry <registry/user>
 
 # Curl the service with the service URL
-curl $(kn service describe node-sample -o url)
+curl $(kn service describe myfunc -o url)
 `,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,12 +18,12 @@ import (
 // resultant binary with no arguments prints the help/usage text.
 var root = &cobra.Command{
 	Use:           "func",
-	Short:         "Manage function projects",
+	Short:         "Serverless functions",
 	SilenceErrors: true, // we explicitly handle errors in Execute()
 	SilenceUsage:  true, // no usage dump on error
-	Long: `Manage function projects.
+	Long: `Serverless functions
 
-Create, build and deploy functions as Knative Services.`,
+Create, build and deploy functions in serverless containers for multiple runtimes on Knative.`,
 }
 
 // NewRootCmd is used to initialize faas as kn plugin
@@ -97,15 +97,15 @@ func cwd() (cwd string) {
 // function defaults and extensible templates.
 func configPath() (path string) {
 	if path = os.Getenv("XDG_CONFIG_HOME"); path != "" {
-		path = filepath.Join(path, "func")
+		path = filepath.Join(path, "function")
 		return
 	}
 	home, err := homedir.Expand("~")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not derive home directory for use as default templates path: %v", err)
-		path = filepath.Join(".config", "func")
+		path = filepath.Join(".config", "function")
 	} else {
-		path = filepath.Join(home, ".config", "func")
+		path = filepath.Join(home, ".config", "function")
 	}
 	return
 }
@@ -217,7 +217,7 @@ func deriveNameAndAbsolutePathFromPath(path string) (string, string) {
 // will be prepended.
 //
 // If the image flag is provided, this value is used directly (the user supplied
-// --image or $FUNC_IMAGE).  Otherwise, the Function at 'path' is loaded, and
+// --image or $FUNCTION_IMAGE).  Otherwise, the Function at 'path' is loaded, and
 // the Image name therein is used (i.e. it was previously calculated).
 // Finally, the default registry is used, which is prepended to the Function
 // name, and appended with ':latest':

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ func runRun(cmd *cobra.Command, args []string) (err error) {
 
 	// Check if the Function has been initialized
 	if !function.Initialized() {
-		return fmt.Errorf("the given path '%v' does not contain an initialized Function.", config.Path)
+		return fmt.Errorf("the given path '%v' does not contain an initialized function", config.Path)
 	}
 
 	runner := docker.NewRunner()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -13,8 +13,8 @@ import (
 func init() {
 	// Add the run command as a subcommand of root.
 	root.AddCommand(runCmd)
-	runCmd.Flags().StringArrayP("env", "e", []string{}, "Sets environment variables for the Function.")
-	runCmd.Flags().StringP("path", "p", cwd(), "Path to the Function project directory - $FUNC_PATH")
+	runCmd.Flags().StringArrayP("env", "e", []string{}, "Environment variable to set in the form NAME=VALUE. You may provide this flag multiple times for setting multiple environment variables.")
+	runCmd.Flags().StringP("path", "p", cwd(), "Path to the project directory (Env: $FUNC_PATH)")
 }
 
 var runCmd = &cobra.Command{
@@ -22,9 +22,15 @@ var runCmd = &cobra.Command{
 	Short: "Run the function locally",
 	Long: `Run the function locally
 
-Runs the Function project in the current directory or in the directory
-specified by the -p or --path flag in the deployable image. The project must
-already have been built as an OCI container image using the 'build' command.
+Runs the function locally in the current directory or in the directory
+specified by --path flag. The function must already have been built with the 'build' command.
+`,
+	Example: `
+# Build function's image first
+kn func build
+
+# Run it locally as a container
+kn func run
 `,
 	SuggestFor: []string{"rnu"},
 	PreRunE:    bindEnv("path"),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -19,8 +19,8 @@ func init() {
 
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Runs the Function locally",
-	Long: `Runs the Function locally
+	Short: "Run the function locally",
+	Long: `Run the function locally
 
 Runs the Function project in the current directory or in the directory
 specified by the -p or --path flag in the deployable image. The project must
@@ -43,7 +43,7 @@ func runRun(cmd *cobra.Command, args []string) (err error) {
 
 	err = function.WriteConfig()
 	if err != nil {
-		return 
+		return
 	}
 
 	// Check if the Function has been initialized

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,7 +26,11 @@ func init() {
 
 var versionCmd = &cobra.Command{
 	Use:        "version",
-	Short:      "Print version.  With --verbose the build date stamp and commit hash are included if available.",
+	Short:      "Show the version",
+	Long:       `Show the version
+
+Ust the --verbose option to include the build date stamp and commit hash"
+`,
 	SuggestFor: []string{"vers", "verison"},
 	Run:        runVersion,
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,7 +29,7 @@ var versionCmd = &cobra.Command{
 	Short:      "Show the version",
 	Long:       `Show the version
 
-Ust the --verbose option to include the build date stamp and commit hash"
+Use the --verbose option to include the build date stamp and commit hash"
 `,
 	SuggestFor: []string{"vers", "verison"},
 	Run:        runVersion,


### PR DESCRIPTION
This commit introduces fixes for the top-level help message as described in #187.

It does not address:

* #216 - Use `kn function` in help message when run as a plugin to kn
* #215 - Group main help message to put important commands to the top
* #214 - Make examples in usage message parameterizable

It also reworked the "build" and "create" commands, but not yet the others.
(this will happen in a follow commit)