### PR TITLE
fix: Fix plugin version output

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"fmt"
 	"github.com/boson-project/faas/cmd"
 	"knative.dev/client/pkg/kn/plugin"
 	"os"

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,9 +1,12 @@
 package plugin
 
 import (
+	"fmt"
 	"github.com/boson-project/faas/cmd"
 	"knative.dev/client/pkg/kn/plugin"
 	"os"
+	"runtime/debug"
+	"strings"
 )
 
 func init() {
@@ -17,7 +20,13 @@ func (f *faasPlugin) Name() string {
 }
 
 func (f *faasPlugin) Execute(args []string) error {
-    rootCmd := cmd.NewRootCmd()
+	rootCmd := cmd.NewRootCmd()
+	info, _ := debug.ReadBuildInfo()
+	for _, dep := range info.Deps {
+		if strings.Contains(dep.Path, "boson-project/faas") {
+			cmd.SetMeta("", dep.Version, dep.Sum)
+		}
+	}
 	oldArgs := os.Args
 	defer (func() {
 		os.Args = oldArgs


### PR DESCRIPTION
@lance @rhuss 

The following code should retrieve and set the actual plugin's version based on go.mod definition. The required change/enhancement on kn's midstream is to use `require` correctly.

It seems a bit cleaner than setting another set of compile flags. Anyway the current set of flags is set through `main` package, so we'd need to change that to pass flags during kn's build.

E.g. from my hacks:

```go
require (
	github.com/boson-project/faas v0.9.0
)

replace (
	github.com/boson-project/faas => /home/dsimansk/Git/boson-project/faas
)
```
```bash
➜  client git:(release-v0.17.3) ✗ kn func version
v0.9.0

```
