### PR TITLE
chore: ensure that pkger is run when templates change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,56 @@ jobs:
       # Checkout and test
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+      - name: Determine platform binaries
+        id: pkger-binaries
+        uses: actions/github-script@v2
+        with:
+          result-encoding: string
+          script: |
+            let platform, binary;
+            switch ('${{matrix.os}}') {
+              case 'ubuntu-latest':
+                platform = 'Linux_x86'
+                binary = 'pkger'
+                break
+              case 'windows-latest':
+                platform = 'Windows_x86'
+                binary = 'pkger.exe'
+                break
+              case 'macos-latest':
+                platform = 'Darwin_x86'
+                binary = 'pkger'
+                break
+            }
+            core.setOutput('platform', platform)
+            core.setOutput('binary', binary)
+      - name: Determine download URL for latest pkger
+        id: pkger-download-url
+        uses: actions/github-script@v2
+        with:
+          result-encoding: string
+          script: |
+            let platform = "${{ steps.pkger-binaries.outputs.platform }}"
+            let binary = "${{ steps.pkger-binaries.outputs.binary }}"
+            core.info('PLATFORM: ' + platform)
+            core.info('BINARY: ' + binary)
+            return github.repos.getReleaseByTag({
+                owner: "markbates",
+                repo: "pkger",
+                tag: "v0.17.1"
+            }).then(result => {
+                return result.data.assets
+                  .filter(a => a.name.includes(platform))
+                  .map(a => a.browser_download_url)[0];
+            })
+      - name: Install pkger
+        run: |
+          curl -s -L -o pkger.tgz ${{ steps.pkger-download-url.outputs.result }}
+          tar xvzf pkger.tgz
       - name: Test
         run:  make test
+        env:
+          PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
       
       # Create a release, or update the release PR
       - uses: GoogleCloudPlatform/release-please-action@v2.5.5
@@ -26,6 +74,9 @@ jobs:
       # Standard build tasks
       - name: Build
         run:  make cross-platform
+        env:
+          PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
+
       - name: Lint
         run: make check
       - name: Permissions

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -12,9 +12,60 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+      - name: Determine platform binaries
+        id: pkger-binaries
+        uses: actions/github-script@v2
+        with:
+          result-encoding: string
+          script: |
+            let platform, binary;
+            switch ('${{matrix.os}}') {
+              case 'ubuntu-latest':
+                platform = 'Linux_x86'
+                binary = 'pkger'
+                break
+              case 'windows-latest':
+                platform = 'Windows_x86'
+                binary = 'pkger.exe'
+                break
+              case 'macos-latest':
+                platform = 'Darwin_x86'
+                binary = 'pkger'
+                break
+            }
+            core.setOutput('platform', platform)
+            core.setOutput('binary', binary)
+      - name: Determine download URL for latest pkger
+        id: pkger-download-url
+        uses: actions/github-script@v2
+        with:
+          result-encoding: string
+          script: |
+            let platform = "${{ steps.pkger-binaries.outputs.platform }}"
+            let binary = "${{ steps.pkger-binaries.outputs.binary }}"
+            core.info('PLATFORM: ' + platform)
+            core.info('BINARY: ' + binary)
+            return github.repos.getReleaseByTag({
+                owner: "markbates",
+                repo: "pkger",
+                tag: "v0.17.1"
+            }).then(result => {
+                return result.data.assets
+                  .filter(a => a.name.includes(platform))
+                  .map(a => a.browser_download_url)[0];
+            })
+      - name: Install pkger
+        run: |
+          curl -s -L -o pkger.tgz ${{ steps.pkger-download-url.outputs.result }}
+          tar xvzf pkger.tgz
+
       - name: Test
         run:  make test
+        env:
+          PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
       - name: Build
         run:  make build
+        env:
+          PKGER: "./${{ steps.pkger-binaries.outputs.binary }}"
       - name: Lint
         run: make check

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 REPO := quay.io/boson/func
 BIN  := func
 
+PKGER?=pkger
+
 DARWIN=$(BIN)_darwin_amd64
 LINUX=$(BIN)_linux_amd64
 WINDOWS=$(BIN)_windows_amd64.exe
@@ -11,10 +13,17 @@ HASH := $(shell git rev-parse --short HEAD 2>/dev/null)
 VTAG := $(shell git tag --points-at HEAD)
 VERS := $(shell [ -z $(VTAG) ] && echo 'tip' || echo $(VTAG) )
 
-build: all
-all: $(BIN)
+TEMPLATE_DIRS=$(shell find templates -type d)
+TEMPLATE_FILES=$(shell find templates -type f -name '*')
+TEMPLATE_PACKAGE=pkged.go
 
-cross-platform: $(DARWIN) $(LINUX) $(WINDOWS)
+build: all
+all: $(TEMPLATE_PACKAGE) $(BIN)
+
+$(TEMPLATE_PACKAGE): templates $(TEMPLATE_DIRS) $(TEMPLATE_FILES)
+	$(PKGER)
+
+cross-platform: $(TEMPLATE_PACKAGE) $(DARWIN) $(LINUX) $(WINDOWS)
 
 darwin: $(DARWIN) ## Build for Darwin (macOS)
 


### PR DESCRIPTION
This commit adds `pkger` to the Makefile, ensuring that when any changes are
made in the `templates` directory it runs. For CI, I've added a download of the
`pkger` binary.

Fixes: https://github.com/boson-project/faas/issues/230

Signed-off-by: Lance Ball <lball@redhat.com>