### PR TITLE
fix: correct fn signatures in Go Events template

### DIFF
--- a/templates/go/events/handle.go
+++ b/templates/go/events/handle.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	cloudevents "github.com/cloudevents/sdk-go/v2"
+	event "github.com/cloudevents/sdk-go/v2"
 )
 
 // Handle a CloudEvent.
@@ -22,7 +22,7 @@ import (
 // * func(event.Event) (*event.Event, error)
 // * func(context.Context, event.Event) *event.Event
 // * func(context.Context, event.Event) (*event.Event, error)
-func Handle(ctx context.Context, event cloudevents.Event) error {
+func Handle(ctx context.Context, event event.Event) error {
 	if err := event.Validate(); err != nil {
 		fmt.Fprintf(os.Stderr, "invalid event received. %v", err)
 		return err

--- a/templates/go/events/handle.go
+++ b/templates/go/events/handle.go
@@ -10,18 +10,18 @@ import (
 
 // Handle a CloudEvent.
 // Supported Function signatures:
-//   func()
-//   func() error
-//   func(context.Context)
-//   func(context.Context) error
-//   func(cloudevents.Event)
-//   func(cloudevents.Event) error
-//   func(context.Context, cloudevents.Event)
-//   func(context.Context, cloudevents.Event) error
-//   func(cloudevents.Event, *cloudevents.EventResponse)
-//   func(cloudevents.Event, *cloudevents.EventResponse) error
-//   func(context.Context, cloudevents.Event, *cloudevents.EventResponse)
-//   func(context.Context, cloudevents.Event, *cloudevents.EventResponse) error
+// * func()
+// * func() error
+// * func(context.Context)
+// * func(context.Context) error
+// * func(event.Event)
+// * func(event.Event) error
+// * func(context.Context, event.Event)
+// * func(context.Context, event.Event) error
+// * func(event.Event) *event.Event
+// * func(event.Event) (*event.Event, error)
+// * func(context.Context, event.Event) *event.Event
+// * func(context.Context, event.Event) (*event.Event, error)
 func Handle(ctx context.Context, event cloudevents.Event) error {
 	if err := event.Validate(); err != nil {
 		fmt.Fprintf(os.Stderr, "invalid event received. %v", err)


### PR DESCRIPTION
Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>

Used signature from Cloudevents Go SDK: https://github.com/cloudevents/sdk-go/blob/e35f432ede703309a1bd4c77a06f4910b3b23582/v2/client/receiver.go#L40-L55
(ust replaced `transport.Result` return value to `error` as `transport.Result` is just [wrapper](https://github.com/cloudevents/sdk-go/blob/5eff2b826cd8f26255f9f6963df66b5a6163a932/v2/protocol/result.go#L9) around `error` type and this is imho more obvious for function developers)

Fixes: #237 
